### PR TITLE
Automatically update `elora-docker` on push and tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,20 @@ jobs:
           CI_COMMIT_AUTHOR: github-actions[bot]
           CI_COMMIT_EMAIL: username@users.noreply.github.com
         run: |
-          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
-          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           if [[ `git status --porcelain --untracked-files=no` ]]; then
+            git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+            git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
             git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
           else
-            echo "ERROR: no changes detected"
-            exit 1
+            echo "no changes detected after checkout"
           fi
       - run: |
           tag=""
           if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
-            echo "this is a tag"
             tag="${{ github.ref }}" && tag=${tag#refs/tags/}
+            echo "pushing new tag $tag to origin"
             git tag $tag && git push origin tag $tag
           else
-            echo "new commits to master"
+            echo "pushing new commit to origin master"
             git push origin master
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,9 @@ jobs:
           fi
       - run: |
           tag=""
-          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} = true ]]; then
+          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} ]]; then
+            echo "this is a tag"
             tag="${{ github.ref }}" && tag=${tag#refs/tags/}
             git tag $tag
             fi
-          git push --atomic origin ci $tag
+          git push --atomic origin master $tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,23 +25,20 @@ jobs:
           git -C ./build/ns-3-dev/ fetch --depth 1 origin refs/tags/$tag
           git -C ./build/ns-3-dev/ checkout FETCH_HEAD
       # - run: touch test.txt && git add .
-      # - run: |
-      #     if [[ "${{ startsWith(github.ref, 'refs/tags/') == 'true' }}" ]]; then
-      #       tag="${{ github.ref }}" && tag=${tag#refs/tags/}
-      #       git tag $tag
-      #       git push --tags
-      #     fi
       - env:
-          CI_COMMIT_MESSAGE: "update elora latest changes"
+          CI_COMMIT_MESSAGE: "pull elora latest changes"
           CI_COMMIT_AUTHOR: github-actions[bot]
           CI_COMMIT_EMAIL: username@users.noreply.github.com
         run: |
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           if [[ `git status --porcelain --untracked-files=no` ]]; then
-            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
-            git push
+            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}" && git push
           else
             echo "no changes to be pushed"
-            exit 0
+          fi
+      - run: |
+          if [[ "${{ startsWith(github.ref, 'refs/tags/') == 'true' }}" ]]; then
+            tag="${{ github.ref }}" && tag=${tag#refs/tags/}
+            git tag $tag && git push -u origin $tag
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           if [[ `git status --porcelain --untracked-files=no` ]]; then
-            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}" && git push
-          else
-            echo "no changes to be pushed"
+            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
           fi
       - run: |
-          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} ]]; then
+          tag=""
+          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} = true ]]; then
             tag="${{ github.ref }}" && tag=${tag#refs/tags/}
-            git tag $tag && git push -u origin $tag
-          fi
+            git tag $tag
+            fi
+          git push --atomic origin ci $tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           tag=$(< ./build/elora/NS3-VERSION) && tag=${tag#release }
           git -C ./build/ns-3-dev/ fetch --depth 1 origin refs/tags/$tag
           git -C ./build/ns-3-dev/ checkout FETCH_HEAD
-      # - run: touch test.txt && git add .
       - env:
           CI_COMMIT_MESSAGE: "pull elora latest changes"
           CI_COMMIT_AUTHOR: github-actions[bot]
@@ -34,12 +33,17 @@ jobs:
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           if [[ `git status --porcelain --untracked-files=no` ]]; then
             git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+          else
+            echo "ERROR: no changes detected"
+            exit 1
           fi
       - run: |
           tag=""
           if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
             echo "this is a tag"
             tag="${{ github.ref }}" && tag=${tag#refs/tags/}
-            git tag $tag
-            fi
-          git push --atomic origin master $tag
+            git tag $tag && git push origin tag $tag
+          else
+            echo "new commits to master"
+            git push origin master
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - ci
+    tags:
+      - v*.*.*
+
+jobs:
+  docker:
+    if: ${{ github.repository == 'non-det-alle/elora' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: non-det-alle/elora-docker-test
+          token: ${{ secrets.ELORA_DOCKER_TEST_TOKEN }}
+          submodules: true
+      - run: |
+          git -C ./build/elora/ fetch --depth 1 origin "${{ github.ref }}"
+          git -C ./build/elora/ checkout FETCH_HEAD
+      - run: |
+          tag=$(< ./build/elora/NS3-VERSION) && tag=${tag#release }
+          git -C ./build/ns-3-dev/ fetch --depth 1 origin refs/tags/$tag
+          git -C ./build/ns-3-dev/ checkout FETCH_HEAD
+      # - run: touch test.txt && git add .
+      # - run: |
+      #     if [[ "${{ startsWith(github.ref, 'refs/tags/') == 'true' }}" ]]; then
+      #       tag="${{ github.ref }}" && tag=${tag#refs/tags/}
+      #       git tag $tag
+      #       git push --tags
+      #     fi
+      - env:
+          CI_COMMIT_MESSAGE: "[bot] update elora latest changes"
+          CI_COMMIT_AUTHOR: github-actions[bot]
+          CI_COMMIT_EMAIL: username@users.noreply.github.com
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+          if [[ `git status --porcelain --untracked-files=no` ]]; then
+            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+            git push
+          else
+            echo "no changes to be pushed"
+            exit 0
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           fi
       - run: |
           tag=""
-          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} ]]; then
+          if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
             echo "this is a tag"
             tag="${{ github.ref }}" && tag=${tag#refs/tags/}
             git tag $tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - ci
+      - master
     tags:
       - v*.*.*
 
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: non-det-alle/elora-docker-test
-          token: ${{ secrets.ELORA_DOCKER_TEST_TOKEN }}
+          repository: non-det-alle/elora-docker
+          token: ${{ secrets.ELORA_DOCKER_TOKEN }}
           submodules: true
       - run: |
           git -C ./build/elora/ fetch --depth 1 origin "${{ github.ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             echo "no changes to be pushed"
           fi
       - run: |
-          if [[ "${{ startsWith(github.ref, 'refs/tags/') == 'true' }}" ]]; then
+          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} ]]; then
             tag="${{ github.ref }}" && tag=${tag#refs/tags/}
             git tag $tag && git push -u origin $tag
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       #       git push --tags
       #     fi
       - env:
-          CI_COMMIT_MESSAGE: "[bot] update elora latest changes"
+          CI_COMMIT_MESSAGE: "update elora latest changes"
           CI_COMMIT_AUTHOR: github-actions[bot]
           CI_COMMIT_EMAIL: username@users.noreply.github.com
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
             echo "pushing new tag $tag to origin"
             git tag $tag && git push origin tag $tag
           else
-            echo "pushing new commit to origin master"
-            git push origin master
+            echo "pushing new commit to origin"
+            git push
           fi


### PR DESCRIPTION
Setup a CI workflow to automatically update the [`elora-docker`](https://github.com/non-det-alle/elora-docker) repository on new commits or tag push in the `non-det-alle/elora` mirror repo. This is part of the automation pipeline to automatically re/build `elora-docker` container images.