### PR TITLE
ADR & retransmissions bug fixes+ tests

### DIFF
--- a/examples/adr-example.cc
+++ b/examples/adr-example.cc
@@ -66,7 +66,6 @@ main(int argc, char* argv[])
                  "ns3::AdrComponent::MultiplePacketsCombiningMethod");
     cmd.AddValue("HistoryRange", "ns3::AdrComponent::HistoryRange");
     cmd.AddValue("FType", "ns3::BaseEndDeviceLorawanMac::FType");
-    cmd.AddValue("ADRBackoff", "ns3::BaseEndDeviceLorawanMac::ADRBackoff");
     cmd.AddValue("ChangeTransmissionPower", "ns3::AdrComponent::ChangeTransmissionPower");
     cmd.AddValue("AdrEnabled", "Whether to enable ADR", adrEnabled);
     cmd.AddValue("nDevices", "Number of devices to simulate", nDevices);
@@ -110,9 +109,6 @@ main(int argc, char* argv[])
     LogComponentEnableAll(LOG_PREFIX_FUNC);
     LogComponentEnableAll(LOG_PREFIX_NODE);
     LogComponentEnableAll(LOG_PREFIX_TIME);
-
-    // Set the EDs to require Data Rate control from the NS
-    Config::SetDefault("ns3::BaseEndDeviceLorawanMac::ADRBit", BooleanValue(true));
 
     // Create a simple wireless channel
     ///////////////////////////////////

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -55,6 +55,9 @@ main(int argc, char* argv[])
     CommandLine cmd;
     cmd.AddValue("nDevices", "Number of end devices to include in the simulation", nDevices);
     cmd.AddValue("radius", "The radius of the area to simulate", radius);
+    cmd.AddValue("realisticChannel",
+                 "Whether to use a more realistic channel model",
+                 realisticChannelModel);
     cmd.AddValue("simulationTime", "The time for which to simulate", simulationTime);
     cmd.AddValue("appPeriod",
                  "The period in seconds to be used by periodically transmitting applications",

--- a/examples/elora-cs-example.cc
+++ b/examples/elora-cs-example.cc
@@ -76,7 +76,7 @@ main(int argc, char* argv[])
         cmd.AddValue("devices", "Number of end devices to include in the simulation", nDevices);
         cmd.AddValue("sir", "Signal to Interference Ratio matrix used for interference", sir);
         cmd.AddValue("initSF", "Whether to initialize the SFs", initializeSF);
-        cmd.AddValue("adr", "ns3::BaseEndDeviceLorawanMac::ADRBit");
+        cmd.AddValue("adr", "ns3::BaseEndDeviceLorawanMac::ADR");
         cmd.AddValue("real", "Use realistic traffic [IEEE C802.16p-11/0102r2]", real);
         cmd.AddValue("file", "Whether to enable .pcap tracing on gateways", file);
         cmd.AddValue("log", "Whether to enable logs", log);
@@ -93,7 +93,6 @@ main(int argc, char* argv[])
     ///////////////// Real-time operation, necessary to interact with the outside world.
     GlobalValue::Bind("SimulatorImplementationType", StringValue("ns3::RealtimeSimulatorImpl"));
     GlobalValue::Bind("ChecksumEnabled", BooleanValue(true));
-    Config::SetDefault("ns3::BaseEndDeviceLorawanMac::ADRBackoff", BooleanValue(true));
     Config::SetDefault("ns3::BaseEndDeviceLorawanMac::EnableCryptography", BooleanValue(true));
     Config::SetDefault("ns3::BaseEndDeviceLorawanMac::FType",
                        EnumValue(LorawanMacHeader::CONFIRMED_DATA_UP));

--- a/examples/elora-tts-example.cc
+++ b/examples/elora-tts-example.cc
@@ -77,7 +77,7 @@ main(int argc, char* argv[])
         cmd.AddValue("devices", "Number of end devices to include in the simulation", nDevices);
         cmd.AddValue("sir", "Signal to Interference Ratio matrix used for interference", sir);
         cmd.AddValue("initSF", "Whether to initialize the SFs", initializeSF);
-        cmd.AddValue("adr", "ns3::BaseEndDeviceLorawanMac::ADRBit");
+        cmd.AddValue("adr", "ns3::BaseEndDeviceLorawanMac::ADR");
         cmd.AddValue("real", "Use realistic traffic [IEEE C802.16p-11/0102r2]", real);
         cmd.AddValue("file", "Whether to enable .pcap tracing on gateways", file);
         cmd.AddValue("log", "Whether to enable logs", log);
@@ -94,7 +94,6 @@ main(int argc, char* argv[])
     ///////////////// Real-time operation, necessary to interact with the outside world.
     GlobalValue::Bind("SimulatorImplementationType", StringValue("ns3::RealtimeSimulatorImpl"));
     GlobalValue::Bind("ChecksumEnabled", BooleanValue(true));
-    Config::SetDefault("ns3::BaseEndDeviceLorawanMac::ADRBackoff", BooleanValue(true));
     Config::SetDefault("ns3::BaseEndDeviceLorawanMac::EnableCryptography", BooleanValue(true));
     Config::SetDefault("ns3::BaseEndDeviceLorawanMac::FType",
                        EnumValue(LorawanMacHeader::CONFIRMED_DATA_UP));

--- a/examples/pcap-example.cc
+++ b/examples/pcap-example.cc
@@ -49,9 +49,6 @@ main(int argc, char* argv[])
      *  Setup  *
      ***********/
 
-    // Set the EDs to require Data Rate control from the NS
-    Config::SetDefault("ns3::BaseEndDeviceLorawanMac::ADRBit", BooleanValue(true));
-
     // Create the time value from the period
     Time appPeriod = Seconds(appPeriodSeconds);
     Time simulationTime = Seconds(simulationTimeSeconds);

--- a/helper/lorawan-mac-helper.cc
+++ b/helper/lorawan-mac-helper.cc
@@ -65,7 +65,14 @@ LorawanMacHelper::Install(Ptr<LoraNetDevice> device) const
     default:
         NS_LOG_ERROR("This region isn't supported yet!");
     }
-    device->SetMac(mac);
+    if (device)
+    {
+        device->SetMac(mac);
+    }
+    else
+    {
+        NS_LOG_WARN("Provided LoraNetDevice is null");
+    }
     return mac;
 }
 

--- a/model/app/server/network-controller-components.cc
+++ b/model/app/server/network-controller-components.cc
@@ -98,6 +98,17 @@ ConfirmedMessagesComponent::OnReceivedPacket(Ptr<const Packet> packet,
         // window. Because of this, in this component's OnFailedReply method we
         // void the ack bits.
     }
+    else if (fHdr.GetAdrAckReq())
+    {
+        NS_LOG_INFO("Packet has ADRACKReq bit set");
+
+        // Configure reply
+        status->m_reply.frameHeader.SetAsDownlink();
+        status->m_reply.frameHeader.SetAck(false);
+        status->m_reply.frameHeader.SetAddress(fHdr.GetAddress());
+        status->m_reply.macHeader.SetFType(LorawanMacHeader::UNCONFIRMED_DATA_DOWN);
+        status->m_reply.needsReply = true;
+    }
 }
 
 void
@@ -176,8 +187,7 @@ LinkCheckComponent::BeforeSendingReply(Ptr<EndDeviceStatus> status,
         // margin
         uint8_t gwCount = status->GetLastReceivedPacketInfo().gwList.size();
 
-        Ptr<LinkCheckAns> replyCommand = Create<LinkCheckAns>();
-        replyCommand->SetGwCnt(gwCount);
+        Ptr<LinkCheckAns> replyCommand = Create<LinkCheckAns>(0, gwCount);
         status->m_reply.frameHeader.SetAsDownlink();
         status->m_reply.frameHeader.AddCommand(replyCommand);
         status->m_reply.macHeader.SetFType(LorawanMacHeader::UNCONFIRMED_DATA_DOWN);

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -90,13 +90,13 @@ BaseEndDeviceLorawanMac::GetTypeId()
                 "communications between this end device "
                 "and a gateway",
                 MakeTraceSourceAccessor(&BaseEndDeviceLorawanMac::m_lastKnownLinkMargin),
-                "ns3::TracedValueCallback::Double")
+                "ns3::TracedValueCallback::uint8_t")
             .AddTraceSource(
                 "LastKnownGatewayCount",
                 "Last known number of gateways able to "
                 "listen to this end device",
                 MakeTraceSourceAccessor(&BaseEndDeviceLorawanMac::m_lastKnownGatewayCount),
-                "ns3::TracedValueCallback::Int")
+                "ns3::TracedValueCallback::uint8_t")
             .AddTraceSource(
                 "AggregatedDutyCycle",
                 "Aggregate duty cycle, in fraction form, "
@@ -486,7 +486,7 @@ BaseEndDeviceLorawanMac::ApplyMACCommands(LoraFrameHeader fHdr, Ptr<const Packet
             // Cast the command
             auto dutyCycleReq = DynamicCast<DutyCycleReq>(cmd);
             // Call the appropriate function to take action
-            OnDutyCycleReq(dutyCycleReq->GetMaximumAllowedDutyCycle());
+            OnDutyCycleReq(dutyCycleReq->GetMaxDutyCycle());
             break;
         }
         case (RX_PARAM_SETUP_REQ): {
@@ -805,8 +805,8 @@ BaseEndDeviceLorawanMac::OnDevStatusReq()
 {
     NS_LOG_FUNCTION(this);
 
-    uint8_t battery = 10; // XXX Fake battery level
-    uint8_t margin = 10;  // XXX Fake margin
+    uint8_t battery = 0; // XXX Fake battery level
+    uint8_t margin = 31; // XXX Fake margin
 
     // Craft a RxParamSetupAns as response
     NS_LOG_INFO("Adding DevStatusAns reply");
@@ -931,6 +931,18 @@ uint8_t
 BaseEndDeviceLorawanMac::GetNumberOfTransmissions() const
 {
     return m_nbTrans;
+}
+
+uint8_t
+BaseEndDeviceLorawanMac::GetLastKnownLinkMarginDb() const
+{
+    return m_lastKnownLinkMargin;
+}
+
+uint8_t
+BaseEndDeviceLorawanMac::GetLastKnownGatewayCount() const
+{
+    return m_lastKnownGatewayCount;
 }
 
 void

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -477,6 +477,7 @@ BaseEndDeviceLorawanMac::ApplyMACCommands(LoraFrameHeader fHdr, Ptr<const Packet
             OnLinkAdrReq(linkAdrReq->GetDataRate(),
                          linkAdrReq->GetTxPower(),
                          linkAdrReq->GetEnabledChannelsList(),
+                         linkAdrReq->GetChMaskCntl(),
                          linkAdrReq->GetRepetitions());
             break;
         }
@@ -613,7 +614,8 @@ void
 BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
                                       uint8_t txPower,
                                       std::list<int> enabledChannels,
-                                      int repetitions)
+                                      uint8_t chMaskCntl,
+                                      uint8_t nbTrans)
 {
     NS_LOG_FUNCTION(this << unsigned(dataRate) << unsigned(txPower) << repetitions);
 

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -521,7 +521,7 @@ BaseEndDeviceLorawanMac::ApplyMACCommands(LoraFrameHeader fHdr, Ptr<const Packet
             // Cast the command
             auto rxTimingSetupReq = DynamicCast<RxTimingSetupReq>(cmd);
             // Call the appropriate function to take action
-            OnRxTimingSetupReq(rxTimingSetupReq->GetDelay());
+            OnRxTimingSetupReq(rxTimingSetupReq->GetDel());
             break;
         }
         case (TX_PARAM_SETUP_REQ): {

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -600,6 +600,15 @@ BaseEndDeviceLorawanMac::OnLinkCheckAns(uint8_t margin, uint8_t gwCnt)
     m_lastKnownGatewayCount = gwCnt;
 }
 
+// Handle LinkADRReq special values according to LoRaWAN ADR semantics.
+// DataRate = 0xF and TXPower = 0xF mean "keep current value", so these
+// fields must not be validated or applied as new settings.
+//
+// References:
+// - Semtech Learn: https://learn.semtech.com/mod/book/view.php?id=174&chapterid=159
+// - See also signetlabdei/lorawan, model/end-device-lorawan-mac.cc:
+// - https://github.com/signetlabdei/lorawan/blob/develop/model/end-device-lorawan-mac.cc
+
 void
 BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
                                       uint8_t txPower,
@@ -624,59 +633,47 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
             break;
         }
     }
-
-    // Check the dataRate
-    /////////////////////
-    // We need to know we can use it at all
-    // To assess this, we try and convert it to a SF/BW combination and check if
-    // those values are valid. Since GetSfFromDataRate and
-    // GetBandwidthFromDataRate return 0 if the dataRate is not recognized, we
-    // can check against this.
-    uint8_t sf = GetSfFromDataRate(dataRate);
-    double bw = GetBandwidthFromDataRate(dataRate);
-    NS_LOG_DEBUG("SF: " << unsigned(sf) << ", BW: " << bw);
-    if (sf == 0 || bw == 0)
-    {
-        dataRateOk = false;
-        NS_LOG_DEBUG("Data rate non valid");
-    }
-
-    // We need to know we can use it in at least one of the enabled channels
-    // Cycle through available channels, stop when at least one is enabled for the
-    // specified dataRate.
-    if (dataRateOk && channelMaskOk) // If false, skip the check
-    {
-        bool foundAvailableChannel = false;
-        for (auto& chIndex : enabledChannels)
-        {
-            auto ch = m_channelManager->GetChannel(chIndex);
-            NS_LOG_DEBUG("MinDR: " << unsigned(ch->GetMinimumDataRate()));
-            NS_LOG_DEBUG("MaxDR: " << unsigned(ch->GetMaximumDataRate()));
-            if (ch->GetMinimumDataRate() <= dataRate && ch->GetMaximumDataRate() >= dataRate)
+    
+    // In LinkADRReq, DataRate = 0xF means "keep current data rate".
+    // It must not be validated as a new DR value or applied to m_dataRate.
+    if (dataRate != 0xF){
+        if(channelMaskOk){
+            bool foundAvailableChannel = false;
+            for (auto& chIndex : enabledChannels)
             {
-                foundAvailableChannel = true;
-                break;
+                auto ch = m_channelManager->GetChannel(chIndex);
+                NS_LOG_DEBUG("MinDR: " << unsigned(ch->GetMinimumDataRate()));
+                NS_LOG_DEBUG("MaxDR: " << unsigned(ch->GetMaximumDataRate()));
+                if (ch->GetMinimumDataRate() <= dataRate && ch->GetMaximumDataRate() >= dataRate)
+                {
+                    foundAvailableChannel = true;
+                    break;
+                }
+            }
+
+            if (!foundAvailableChannel)
+            {
+                dataRateOk = false;
+                NS_LOG_DEBUG("Available channel not found");
             }
         }
-
-        if (!foundAvailableChannel)
-        {
-            dataRateOk = false;
-            NS_LOG_DEBUG("Available channel not found");
-        }
     }
 
-    // Check the txPower
-    ////////////////////
-    // Check whether we can use this transmission power
-    if (GetDbmForTxPower(txPower) == -1)
+    // In LinkADRReq, TXPower = 0xF means "keep current tx power".
+    // Only validate and apply txPower when a new value is actually requested.
+    if (txPower != 0xF) // If value is 0xF, ignore config.
     {
-        txPowerOk = false;
+        // Check if it is acceptable
+        if (GetDbmForTxPower(txPower) < 0)
+        {
+            NS_LOG_WARN("Invalid tx power");
+            txPowerOk = false;
+        }
     }
 
     NS_LOG_DEBUG("Finished checking. " << "ChannelMaskOk: " << channelMaskOk << ", "
                                        << "DataRateOk: " << dataRateOk << ", "
-                                       << "txPowerOk: " << txPowerOk);
+                                       << "txPowerOk: " << txPowerOk << " | Dev Addr.: " << m_address);
 
     // If all checks are successful, set parameters up
     //////////////////////////////////////////////////
@@ -698,14 +695,21 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
             }
         }
 
-        // Set the data rate
-        m_dataRate = dataRate;
+        if (txPower != 0xF) // If value is 0xF, ignore config.
+        {
+            m_txPower = GetDbmForTxPower(txPower);
+        }
 
-        // Set the transmission power
-        m_txPower = GetDbmForTxPower(txPower);
+        if (dataRate != 0xF) // If value is 0xF, ignore config.
+        {
+            m_dataRate = dataRate;
+        }
+
 
         // Set the number of redundant transmissions
         m_nbTrans = repetitions;
+
+        NS_LOG_DEBUG("DR: " << unsigned(m_dataRate) << " | TX Power: " << m_txPower << " | m_nbTrans: " << unsigned(m_nbTrans) << " | Dev Addr.: " << m_address);
     }
 
     // Craft a LinkAdrAns MAC command as a response

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -41,7 +41,7 @@ BaseEndDeviceLorawanMac::GetTypeId()
                           MakeUintegerChecker<uint8_t>(0, 5))
             .AddAttribute("ADRBit",
                           "Whether to request the NS to control this device's Data Rate",
-                          BooleanValue(),
+                          BooleanValue(true),
                           MakeBooleanAccessor(&BaseEndDeviceLorawanMac::m_ADRBit),
                           MakeBooleanChecker())
             .AddAttribute("NbTrans",
@@ -117,7 +117,7 @@ BaseEndDeviceLorawanMac::BaseEndDeviceLorawanMac()
       // Private Header fields
       m_fType(LorawanMacHeader::UNCONFIRMED_DATA_UP),
       m_address(LoraDeviceAddress(0)),
-      m_ADRBit(false),
+      m_ADRBit(true),
       m_fCnt(0),
       // Private MAC layer settings
       m_enableADRBackoff(false),

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -41,22 +41,20 @@ BaseEndDeviceLorawanMac::GetTypeId()
                           UintegerValue(0),
                           MakeUintegerAccessor(&BaseEndDeviceLorawanMac::m_dataRate),
                           MakeUintegerChecker<uint8_t>(0, 5))
-            .AddAttribute("ADRBit",
-                          "Whether to request the NS to control this device's Data Rate",
-                          BooleanValue(true),
-                          MakeBooleanAccessor(&BaseEndDeviceLorawanMac::m_ADRBit),
-                          MakeBooleanChecker())
+            .AddAttribute(
+                "ADR",
+                "Ensure to the network server that this device will accept data rate, transmission "
+                "power and number of retransmissions configurations received via LinkADRReq. This "
+                "also allows the device's local ADR backoff procedure to reset configurations in "
+                "case of connectivity loss.",
+                BooleanValue(true),
+                MakeBooleanAccessor(&BaseEndDeviceLorawanMac::m_adr),
+                MakeBooleanChecker())
             .AddAttribute("NbTrans",
                           "Default number of transmissions for each packet",
                           IntegerValue(1),
                           MakeIntegerAccessor(&BaseEndDeviceLorawanMac::m_nbTrans),
                           MakeIntegerChecker<uint8_t>())
-            .AddAttribute("ADRBackoff",
-                          "Whether the End Device should up its Data Rate "
-                          "in case it doesn't get a reply from the NS.",
-                          BooleanValue(false),
-                          MakeBooleanAccessor(&BaseEndDeviceLorawanMac::m_enableADRBackoff),
-                          MakeBooleanChecker())
             .AddAttribute(
                 "FType",
                 "Specify type of message will be sent by this ED.",
@@ -120,9 +118,7 @@ BaseEndDeviceLorawanMac::BaseEndDeviceLorawanMac()
       // Private Header fields
       m_fType(LorawanMacHeader::UNCONFIRMED_DATA_UP),
       m_address(LoraDeviceAddress(0)),
-      m_ADRBit(true),
       // Private MAC layer settings
-      m_enableADRBackoff(false),
       m_enableCrypto(false),
       m_aggregatedDutyCycle(1),
       // Private MAC layer context
@@ -248,7 +244,7 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
         NS_LOG_DEBUG("Retransmitting an old packet.");
     }
 
-    if (m_enableADRBackoff)
+    if (m_adr)
     {
         // ADR backoff as in LoRaWAN specification, V1.0.4 (2020)
         ExecuteADRBackoff();
@@ -388,7 +384,7 @@ BaseEndDeviceLorawanMac::FillHeader(LoraFrameHeader& fHdr)
     fHdr.SetAsUplink();
     fHdr.SetFPort(1); // TODO Use an appropriate frame port based on the application
     fHdr.SetAddress(m_address);
-    fHdr.SetAdr(m_ADRBit);
+    fHdr.SetAdr(m_adr);
     fHdr.SetAdrAckReq(m_ADRACKReq);
 
     // FPending does not exist in uplink messages
@@ -673,7 +669,7 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
     }
 
     // Temporary channel mask is built and validated
-    if (!m_ADRBit) // ADR disabled, only consider channel mask conf.
+    if (!m_adr) // ADR disabled, only consider channel mask conf.
     {
         /// @remark Original code considers this to be mobile-mode
         if (channelMaskAck) // valid channel mask
@@ -936,18 +932,6 @@ uint8_t
 BaseEndDeviceLorawanMac::GetNumberOfTransmissions() const
 {
     return m_nbTrans;
-}
-
-void
-BaseEndDeviceLorawanMac::SetADRBackoff(bool backoff)
-{
-    m_enableADRBackoff = backoff;
-}
-
-bool
-BaseEndDeviceLorawanMac::GetADRBackoff() const
-{
-    return m_enableADRBackoff;
 }
 
 void

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -113,8 +113,8 @@ BaseEndDeviceLorawanMac::BaseEndDeviceLorawanMac()
       m_nbTrans(1),
       // Protected MAC layer context
       m_fCnt(0),
-      m_ADRACKCnt(0),
-      m_ADRACKReq(false),
+      m_adrAckCnt(0),
+      m_adrAckReq(false),
       // Private Header fields
       m_fType(LorawanMacHeader::UNCONFIRMED_DATA_UP),
       m_address(LoraDeviceAddress(0)),
@@ -219,10 +219,7 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
             }
             // Update frame counter and ADRACKCnt (normally updated after exhausting all reTxs)
             m_fCnt++;
-            if (m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
-            {
-                m_ADRACKCnt++;
-            }
+            m_adrAckCnt++;
         }
         // Reset reTx context
         m_txContext = {.firstAttempt = Simulator::Now(),
@@ -244,11 +241,16 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
         NS_LOG_DEBUG("Retransmitting an old packet.");
     }
 
-    if (m_adr)
+    // Evaluate ADR backoff as in LoRaWAN specification, V1.0.4 (2020)
+    // Adapted from: github.com/Lora-net/SWL2001.git v4.8.0
+    m_adrAckReq = (m_adrAckCnt >= ADR_ACK_LIMIT); // Set the ADRACKReq bit in frame header
+    if (m_adrAckCnt >= ADR_ACK_LIMIT + ADR_ACK_DELAY)
     {
-        // ADR backoff as in LoRaWAN specification, V1.0.4 (2020)
+        // Unreachable by retx: they do not increase ADRACKCnt
         ExecuteADRBackoff();
+        m_adrAckCnt = ADR_ACK_LIMIT;
     }
+    NS_ASSERT(m_adrAckCnt < 2400);
 
     // Add the Lora Frame Header to the packet
     LoraFrameHeader fHdr;
@@ -293,30 +295,31 @@ BaseEndDeviceLorawanMac::ExecuteADRBackoff()
 {
     NS_LOG_FUNCTION(this);
 
-    // ADR backoff as in LoRaWAN specification, V1.0.4 (2020)
-    if (m_ADRACKCnt == ADR_ACK_LIMIT)
+    // Adapted from: github.com/Lora-net/SWL2001.git v4.8.0
+    // For the time being, this implementation is valid for the EU868 region
+
+    if (!m_adr)
     {
-        m_ADRACKReq = true; // Set the ADRACKReq bit in frame header
+        return;
     }
-    else if (m_ADRACKCnt == ADR_ACK_LIMIT + ADR_ACK_DELAY)
+
+    if (m_txPower < 14)
     {
         m_txPower = 14; // Reset transmission power to default
+        return;
     }
-    else if (m_ADRACKCnt > ADR_ACK_LIMIT && !((m_ADRACKCnt - ADR_ACK_LIMIT) % ADR_ACK_DELAY))
+
+    if (m_dataRate != 0)
     {
-        if (m_dataRate)
-        {
-            m_dataRate--; // Decrease data rate
-        }
-        else
-        {
-            // Enable default channels and set nbTrans to 1
-            m_channelManager->GetChannel(0)->EnableForUplink();
-            m_channelManager->GetChannel(1)->EnableForUplink();
-            m_channelManager->GetChannel(2)->EnableForUplink();
-            m_nbTrans = 1;
-        }
+        m_dataRate--;
+        return;
     }
+
+    // Set nbTrans to 1 and re-enable default channels
+    m_nbTrans = 1;
+    m_channelManager->GetChannel(0)->EnableForUplink();
+    m_channelManager->GetChannel(1)->EnableForUplink();
+    m_channelManager->GetChannel(2)->EnableForUplink();
 }
 
 Ptr<LogicalChannel>
@@ -385,7 +388,7 @@ BaseEndDeviceLorawanMac::FillHeader(LoraFrameHeader& fHdr)
     fHdr.SetFPort(1); // TODO Use an appropriate frame port based on the application
     fHdr.SetAddress(m_address);
     fHdr.SetAdr(m_adr);
-    fHdr.SetAdrAckReq(m_ADRACKReq);
+    fHdr.SetAdrAckReq(m_adrAckReq);
 
     // FPending does not exist in uplink messages
     fHdr.SetFCnt(m_fCnt);

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -785,9 +785,11 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
 }
 
 void
-BaseEndDeviceLorawanMac::OnDutyCycleReq(double dutyCycle)
+BaseEndDeviceLorawanMac::OnDutyCycleReq(uint8_t maxDutyCycle)
 {
-    NS_LOG_FUNCTION(this << dutyCycle);
+    NS_LOG_FUNCTION(this << unsigned(maxDutyCycle));
+
+    auto dutyCycle = (maxDutyCycle) ? 1 / std::pow(2, double(maxDutyCycle)) : 1;
 
     // Make sure we get a value that makes sense
     NS_ASSERT(0 <= dutyCycle && dutyCycle <= 1);

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -107,19 +107,15 @@ BaseEndDeviceLorawanMac::GetTypeId()
 }
 
 BaseEndDeviceLorawanMac::BaseEndDeviceLorawanMac()
-    // Protected MAC layer settings
-    : m_dataRate(0),
+    : // Protected MAC layer settings
       m_txPower(14),
-      m_nbTrans(1),
       // Protected MAC layer context
       m_fCnt(0),
       m_adrAckCnt(0),
       m_adrAckReq(false),
       // Private Header fields
-      m_fType(LorawanMacHeader::UNCONFIRMED_DATA_UP),
       m_address(LoraDeviceAddress(0)),
       // Private MAC layer settings
-      m_enableCrypto(false),
       m_aggregatedDutyCycle(1),
       // Private MAC layer context
       m_lastKnownLinkMargin(0),

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -18,6 +18,8 @@
 #include "ns3/end-device-lora-phy.h"
 #include "ns3/simulator.h"
 
+#include <bitset>
+
 namespace ns3
 {
 namespace lorawan
@@ -476,14 +478,12 @@ BaseEndDeviceLorawanMac::ApplyMACCommands(LoraFrameHeader fHdr, Ptr<const Packet
         }
         case (LINK_ADR_REQ): {
             NS_LOG_DEBUG("Detected a LinkAdrReq command.");
-            // Cast the command
             auto linkAdrReq = DynamicCast<LinkAdrReq>(cmd);
-            // Call the appropriate function to take action
             OnLinkAdrReq(linkAdrReq->GetDataRate(),
                          linkAdrReq->GetTxPower(),
-                         linkAdrReq->GetEnabledChannelsList(),
+                         linkAdrReq->GetChMask(),
                          linkAdrReq->GetChMaskCntl(),
-                         linkAdrReq->GetRepetitions());
+                         linkAdrReq->GetNbTrans());
             break;
         }
         case (DUTY_CYCLE_REQ): {
@@ -609,15 +609,16 @@ BaseEndDeviceLorawanMac::OnLinkCheckAns(uint8_t margin, uint8_t gwCnt)
 void
 BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
                                       uint8_t txPower,
-                                      std::list<int> enabledChannels,
+                                      uint16_t chMask,
                                       uint8_t chMaskCntl,
                                       uint8_t nbTrans)
 {
-    NS_LOG_FUNCTION(this << unsigned(dataRate) << unsigned(txPower) << enabledChannels
+    NS_LOG_FUNCTION(this << unsigned(dataRate) << unsigned(txPower) << std::bitset<16>(chMask)
                          << unsigned(chMaskCntl) << unsigned(nbTrans));
 
     // Adapted from: github.com/Lora-net/SWL2001.git v4.3.1
     // For the time being, this implementation is valid for the EU868 region
+    const uint8_t NUM_CHAN = 16;
 
     NS_ASSERT_MSG(!(dataRate & 0xF0), "dataRate field > 4 bits");
     NS_ASSERT_MSG(!(txPower & 0xF0), "txPower field > 4 bits");
@@ -628,15 +629,18 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
     bool dataRateAck = true;
     bool powerAck = true;
 
+    NS_LOG_DEBUG("Channel mask = " << std::bitset<16>(chMask)
+                                   << ", ChMaskCtrl = " << unsigned(chMaskCntl));
+
     // Check channel mask
     switch (chMaskCntl)
     {
     // Channels 0 to 15
     case 0:
-        // Check whether all specified channels exist on this device
-        for (auto& i : enabledChannels)
+        // Check if all enabled channels have a valid frequency
+        for (size_t i = 0; i < NUM_CHAN; ++i)
         {
-            if (!m_channelManager->GetChannel(i))
+            if ((chMask & 0b1 << i) && !m_channelManager->GetChannel(i))
             {
                 NS_LOG_WARN("Invalid channel mask");
                 channelMaskAck = false;
@@ -646,12 +650,12 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
         break;
     // All channels ON independently of the ChMask field value
     case 6:
-        enabledChannels.clear();
-        for (size_t i = 0; i < 256; ++i)
+        chMask = 0b0;
+        for (size_t i = 0; i < NUM_CHAN; ++i)
         {
             if (m_channelManager->GetChannel(i))
             {
-                enabledChannels.emplace_back(i);
+                chMask |= 0b1 << i;
             }
         }
         break;
@@ -662,7 +666,7 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
     }
 
     // check if all channels are disabled
-    if (enabledChannels.empty())
+    if (chMask == 0)
     {
         NS_LOG_WARN("Invalid channel mask");
         channelMaskAck = false;
@@ -676,9 +680,10 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
         {
             bool compatible = false;
             // Look for enabled channel that supports current data rate.
-            for (auto& i : enabledChannels)
+            for (size_t i = 0; i < NUM_CHAN; ++i)
             {
-                if (m_dataRate >= m_channelManager->GetChannel(i)->GetMinimumDataRate() &&
+                if ((chMask & 0b1 << i) &&
+                    m_dataRate >= m_channelManager->GetChannel(i)->GetMinimumDataRate() &&
                     m_dataRate <= m_channelManager->GetChannel(i)->GetMaximumDataRate())
                 { // Found compatible channel, break loop
                     compatible = true;
@@ -692,14 +697,11 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
             }
             else // apply channel mask configuration
             {
-                for (size_t i = 0; i < 256; ++i)
+                for (size_t i = 0; i < NUM_CHAN; ++i)
                 {
                     if (auto c = m_channelManager->GetChannel(i); c)
                     {
-                        (std::find(enabledChannels.begin(), enabledChannels.end(), i) !=
-                         enabledChannels.end())
-                            ? c->EnableForUplink()
-                            : c->DisableForUplink();
+                        (chMask & 0b1 << i) ? c->EnableForUplink() : c->DisableForUplink();
                     }
                 }
                 dataRateAck = powerAck = false; // only ack channel mask
@@ -717,26 +719,29 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
         {
             bool compatible = false;
             // Look for enabled channel that supports config. data rate.
-            for (auto i : enabledChannels) // all enabled by chMask, even if it was invalid
+            for (size_t i = 0; i < NUM_CHAN; ++i)
             {
-                if (const auto& c = m_channelManager->GetChannel(i); c) // exists
+                if (chMask & 0b1 << i) // all enabled by chMask, even if it was invalid
                 {
-                    if (dataRate >= c->GetMinimumDataRate() && dataRate <= c->GetMaximumDataRate())
-                    { // Found compatible channel, break loop
-                        compatible = true;
-                        break;
+                    if (const auto& c = m_channelManager->GetChannel(i); c) // exists
+                    {
+                        if (dataRate >= c->GetMinimumDataRate() &&
+                            dataRate <= c->GetMaximumDataRate())
+                        { // Found compatible channel, break loop
+                            compatible = true;
+                            break;
+                        }
                     }
-                }
-                else // manages invalid case, checks with defaults
-                {
-                    if (GetSfFromDataRate(dataRate) && GetBandwidthFromDataRate(dataRate))
-                    { // Found compatible (invalid) channel, break loop
-                        compatible = true;
-                        break;
+                    else // manages invalid case, checks with defaults
+                    {
+                        if (GetSfFromDataRate(dataRate) && GetBandwidthFromDataRate(dataRate))
+                        { // Found compatible (invalid) channel, break loop
+                            compatible = true;
+                            break;
+                        }
                     }
                 }
             }
-
             // Check if it is acceptable
             if (!compatible)
             {
@@ -758,14 +763,11 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
         // If no error, apply configurations
         if (channelMaskAck && dataRateAck && powerAck)
         {
-            for (size_t i = 0; i < 256; ++i)
+            for (size_t i = 0; i < NUM_CHAN; ++i)
             {
                 if (auto c = m_channelManager->GetChannel(i); c)
                 {
-                    (std::find(enabledChannels.begin(), enabledChannels.end(), i) !=
-                     enabledChannels.end())
-                        ? c->EnableForUplink()
-                        : c->DisableForUplink();
+                    (chMask & 0b1 << i) ? c->EnableForUplink() : c->DisableForUplink();
                 }
             }
             if (txPower != 0xF) // If value is 0xF, ignore config.

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -601,15 +601,6 @@ BaseEndDeviceLorawanMac::OnLinkCheckAns(uint8_t margin, uint8_t gwCnt)
     m_lastKnownGatewayCount = gwCnt;
 }
 
-// Handle LinkADRReq special values according to LoRaWAN ADR semantics.
-// DataRate = 0xF and TXPower = 0xF mean "keep current value", so these
-// fields must not be validated or applied as new settings.
-//
-// References:
-// - Semtech Learn: https://learn.semtech.com/mod/book/view.php?id=174&chapterid=159
-// - See also signetlabdei/lorawan, model/end-device-lorawan-mac.cc:
-// - https://github.com/signetlabdei/lorawan/blob/develop/model/end-device-lorawan-mac.cc
-
 void
 BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
                                       uint8_t txPower,
@@ -617,106 +608,178 @@ BaseEndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
                                       uint8_t chMaskCntl,
                                       uint8_t nbTrans)
 {
-    NS_LOG_FUNCTION(this << unsigned(dataRate) << unsigned(txPower) << repetitions);
+    NS_LOG_FUNCTION(this << unsigned(dataRate) << unsigned(txPower) << enabledChannels
+                         << unsigned(chMaskCntl) << unsigned(nbTrans));
 
-    // Three bools for three requirements before setting things up
-    bool channelMaskOk = !enabledChannels.empty();
-    bool dataRateOk = true;
-    bool txPowerOk = true;
+    // Adapted from: github.com/Lora-net/SWL2001.git v4.3.1
+    // For the time being, this implementation is valid for the EU868 region
 
-    // Check the channel mask
-    /////////////////////////
-    // Check whether all specified channels exist on this device
-    for (auto& chIndex : enabledChannels)
+    NS_ASSERT_MSG(!(dataRate & 0xF0), "dataRate field > 4 bits");
+    NS_ASSERT_MSG(!(txPower & 0xF0), "txPower field > 4 bits");
+    NS_ASSERT_MSG(!(chMaskCntl & 0xF8), "chMaskCntl field > 3 bits");
+    NS_ASSERT_MSG(!(nbTrans & 0xF0), "nbTrans field > 4 bits");
+
+    bool channelMaskAck = true;
+    bool dataRateAck = true;
+    bool powerAck = true;
+
+    // Check channel mask
+    switch (chMaskCntl)
     {
-        if (!m_channelManager->GetChannel(chIndex))
+    // Channels 0 to 15
+    case 0:
+        // Check whether all specified channels exist on this device
+        for (auto& i : enabledChannels)
         {
-            channelMaskOk = false;
-            break;
-        }
-    }
-    
-    // In LinkADRReq, DataRate = 0xF means "keep current data rate".
-    // It must not be validated as a new DR value or applied to m_dataRate.
-    if (dataRate != 0xF){
-        if(channelMaskOk){
-            bool foundAvailableChannel = false;
-            for (auto& chIndex : enabledChannels)
+            if (!m_channelManager->GetChannel(i))
             {
-                auto ch = m_channelManager->GetChannel(chIndex);
-                NS_LOG_DEBUG("MinDR: " << unsigned(ch->GetMinimumDataRate()));
-                NS_LOG_DEBUG("MaxDR: " << unsigned(ch->GetMaximumDataRate()));
-                if (ch->GetMinimumDataRate() <= dataRate && ch->GetMaximumDataRate() >= dataRate)
-                {
-                    foundAvailableChannel = true;
+                NS_LOG_WARN("Invalid channel mask");
+                channelMaskAck = false;
+                break; // break for loop
+            }
+        }
+        break;
+    // All channels ON independently of the ChMask field value
+    case 6:
+        enabledChannels.clear();
+        for (size_t i = 0; i < 256; ++i)
+        {
+            if (m_channelManager->GetChannel(i))
+            {
+                enabledChannels.emplace_back(i);
+            }
+        }
+        break;
+    default:
+        NS_LOG_WARN("Invalid channel mask ctrl field");
+        channelMaskAck = false;
+        break;
+    }
+
+    // check if all channels are disabled
+    if (enabledChannels.empty())
+    {
+        NS_LOG_WARN("Invalid channel mask");
+        channelMaskAck = false;
+    }
+
+    // Temporary channel mask is built and validated
+    if (!m_ADRBit) // ADR disabled, only consider channel mask conf.
+    {
+        /// @remark Original code considers this to be mobile-mode
+        if (channelMaskAck) // valid channel mask
+        {
+            bool compatible = false;
+            // Look for enabled channel that supports current data rate.
+            for (auto& i : enabledChannels)
+            {
+                if (m_dataRate >= m_channelManager->GetChannel(i)->GetMinimumDataRate() &&
+                    m_dataRate <= m_channelManager->GetChannel(i)->GetMaximumDataRate())
+                { // Found compatible channel, break loop
+                    compatible = true;
                     break;
                 }
             }
-
-            if (!foundAvailableChannel)
+            if (!compatible)
             {
-                dataRateOk = false;
-                NS_LOG_DEBUG("Available channel not found");
+                NS_LOG_WARN("Invalid channel mask for current device data rate (ADR off)");
+                channelMaskAck = dataRateAck = powerAck = false; // reject all configurations
+            }
+            else // apply channel mask configuration
+            {
+                for (size_t i = 0; i < 256; ++i)
+                {
+                    if (auto c = m_channelManager->GetChannel(i); c)
+                    {
+                        (std::find(enabledChannels.begin(), enabledChannels.end(), i) !=
+                         enabledChannels.end())
+                            ? c->EnableForUplink()
+                            : c->DisableForUplink();
+                    }
+                }
+                dataRateAck = powerAck = false; // only ack channel mask
             }
         }
-    }
-
-    // In LinkADRReq, TXPower = 0xF means "keep current tx power".
-    // Only validate and apply txPower when a new value is actually requested.
-    if (txPower != 0xF) // If value is 0xF, ignore config.
-    {
-        // Check if it is acceptable
-        if (GetDbmForTxPower(txPower) < 0)
+        else // reject
         {
-            NS_LOG_WARN("Invalid tx power");
-            txPowerOk = false;
+            NS_LOG_WARN("Invalid channel mask");
+            dataRateAck = powerAck = false; // reject all configurations
         }
     }
-
-    NS_LOG_DEBUG("Finished checking. " << "ChannelMaskOk: " << channelMaskOk << ", "
-                                       << "DataRateOk: " << dataRateOk << ", "
-                                       << "txPowerOk: " << txPowerOk << " | Dev Addr.: " << m_address);
-
-    // If all checks are successful, set parameters up
-    //////////////////////////////////////////////////
-    if (channelMaskOk && dataRateOk && txPowerOk)
+    else // Server-side ADR is enabled
     {
-        // Cycle over all channels in the list
-        for (uint32_t i = 0; i < m_channelManager->GetChannelList().size(); i++)
+        if (dataRate != 0xF) // If value is 0xF, ignore config.
         {
-            if (std::find(enabledChannels.begin(), enabledChannels.end(), i) !=
-                enabledChannels.end())
+            bool compatible = false;
+            // Look for enabled channel that supports config. data rate.
+            for (auto i : enabledChannels) // all enabled by chMask, even if it was invalid
             {
-                m_channelManager->GetChannelList().at(i)->EnableForUplink();
-                NS_LOG_DEBUG("Channel " << i << " enabled");
+                if (const auto& c = m_channelManager->GetChannel(i); c) // exists
+                {
+                    if (dataRate >= c->GetMinimumDataRate() && dataRate <= c->GetMaximumDataRate())
+                    { // Found compatible channel, break loop
+                        compatible = true;
+                        break;
+                    }
+                }
+                else // manages invalid case, checks with defaults
+                {
+                    if (GetSfFromDataRate(dataRate) && GetBandwidthFromDataRate(dataRate))
+                    { // Found compatible (invalid) channel, break loop
+                        compatible = true;
+                        break;
+                    }
+                }
             }
-            else
+
+            // Check if it is acceptable
+            if (!compatible)
             {
-                m_channelManager->GetChannelList().at(i)->DisableForUplink();
-                NS_LOG_DEBUG("Channel " << i << " disabled");
+                NS_LOG_WARN("Invalid data rate");
+                dataRateAck = false;
             }
         }
 
         if (txPower != 0xF) // If value is 0xF, ignore config.
         {
-            m_txPower = GetDbmForTxPower(txPower);
+            // Check if it is acceptable
+            if (GetDbmForTxPower(txPower) < 0)
+            {
+                NS_LOG_WARN("Invalid tx power");
+                powerAck = false;
+            }
         }
 
-        if (dataRate != 0xF) // If value is 0xF, ignore config.
+        // If no error, apply configurations
+        if (channelMaskAck && dataRateAck && powerAck)
         {
-            m_dataRate = dataRate;
+            for (size_t i = 0; i < 256; ++i)
+            {
+                if (auto c = m_channelManager->GetChannel(i); c)
+                {
+                    (std::find(enabledChannels.begin(), enabledChannels.end(), i) !=
+                     enabledChannels.end())
+                        ? c->EnableForUplink()
+                        : c->DisableForUplink();
+                }
+            }
+            if (txPower != 0xF) // If value is 0xF, ignore config.
+            {
+                m_txPower = GetDbmForTxPower(txPower);
+            }
+            m_nbTrans = (nbTrans == 0) ? 1 : nbTrans;
+            if (dataRate != 0xF) // If value is 0xF, ignore config.
+            {
+                m_dataRate = dataRate;
+            }
+            NS_LOG_DEBUG("MacTxDataRateAdr = " << unsigned(m_dataRate));
+            NS_LOG_DEBUG("MacTxPower = " << unsigned(m_txPower) << "dBm");
+            NS_LOG_DEBUG("MacNbTrans = " << unsigned(m_nbTrans));
         }
-
-
-        // Set the number of redundant transmissions
-        m_nbTrans = repetitions;
-
-        NS_LOG_DEBUG("DR: " << unsigned(m_dataRate) << " | TX Power: " << m_txPower << " | m_nbTrans: " << unsigned(m_nbTrans) << " | Dev Addr.: " << m_address);
     }
 
-    // Craft a LinkAdrAns MAC command as a response
-    ///////////////////////////////////////////////
-    m_fOpts.emplace_back(Create<LinkAdrAns>(txPowerOk, dataRateOk, channelMaskOk));
+    NS_LOG_INFO("Adding LinkAdrAns reply");
+    m_fOpts.emplace_back(Create<LinkAdrAns>(powerAck, dataRateAck, channelMaskAck));
 }
 
 void

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -202,16 +202,14 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
         // If re-transmissions of last packet were interrupted, update frame counters
         if (m_txContext.nbTxLeft)
         {
+            NS_LOG_DEBUG("New packet from the APP layer: stopping retransmission process");
             // Trace if previous confirmed packet was not acknowledged
             if (m_txContext.waitingAck)
             {
                 uint8_t txs = m_nbTrans - m_txContext.nbTxLeft;
                 m_requiredTxCallback(txs, false, m_txContext.firstAttempt, m_txContext.packet);
-                NS_LOG_DEBUG(
-                    " Received new packet from the application layer: stopping retransmission "
-                    "procedure. Previous packet not acknowledged. Used "
-                    << unsigned(txs) << " transmissions out of a maximum of " << unsigned(m_nbTrans)
-                    << ".");
+                NS_LOG_DEBUG("Previous packet not acknowledged, used "
+                             << unsigned(txs) << " transmissions out of " << unsigned(m_nbTrans));
             }
             // Update frame counter and ADRACKCnt (normally updated after exhausting all reTxs)
             m_fCnt++;
@@ -223,7 +221,6 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
                        .nbTxLeft = m_nbTrans,
                        .waitingAck = (m_fType == LorawanMacHeader::CONFIRMED_DATA_UP),
                        .busy = false};
-        NS_LOG_DEBUG("New APP packet: " << packet << ".");
     }
     else // Retransmission
     {
@@ -378,7 +375,7 @@ BaseEndDeviceLorawanMac::AddMacCommand(Ptr<MacCommand> macCommand)
 void
 BaseEndDeviceLorawanMac::FillHeader(LoraFrameHeader& fHdr)
 {
-    NS_LOG_FUNCTION(this << fHdr);
+    NS_LOG_FUNCTION(this);
 
     fHdr.SetAsUplink();
     fHdr.SetFPort(1); // TODO Use an appropriate frame port based on the application
@@ -409,15 +406,19 @@ BaseEndDeviceLorawanMac::FillHeader(LoraFrameHeader& fHdr)
     // Reset MAC command list
     // (but leave DlChannelAns and RxTimingSetupAns)
     m_fOpts = tmpCmdList;
+
+    NS_LOG_DEBUG(fHdr);
 }
 
 void
 BaseEndDeviceLorawanMac::FillHeader(LorawanMacHeader& mHdr)
 {
-    NS_LOG_FUNCTION(this << mHdr);
+    NS_LOG_FUNCTION(this);
 
     mHdr.SetFType(m_fType);
     mHdr.SetMajor(0);
+
+    NS_LOG_DEBUG(mHdr);
 }
 
 void
@@ -933,6 +934,12 @@ uint8_t
 BaseEndDeviceLorawanMac::GetNumberOfTransmissions() const
 {
     return m_nbTrans;
+}
+
+uint16_t
+BaseEndDeviceLorawanMac::GetFCnt() const
+{
+    return m_fCnt;
 }
 
 uint8_t

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -414,10 +414,9 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     /**
      * Perform the actions that need to be taken when receiving a DutyCycleReq command.
      *
-     * \param dutyCycle The aggregate duty cycle prescribed by the command, in
-     * fraction form.
+     * \param dutyCycle The aggregate duty cycle parameter from the command
      */
-    void OnDutyCycleReq(double dutyCycle);
+    void OnDutyCycleReq(uint8_t maxDutyCycle);
 
     /**
      * Perform the actions that need to be taken when receiving a RxParamSetupReq command.

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -442,7 +442,7 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     /**
      * Perform the actions that need to be taken when receiving a RxTimingSetupReq command.
      */
-    virtual void OnRxTimingSetupReq(Time delay) = 0;
+    virtual void OnRxTimingSetupReq(uint8_t del) = 0;
 
     /**
      * Perform the actions that need to be taken when receiving a DlChannelReq command.

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -184,18 +184,6 @@ class BaseEndDeviceLorawanMac : public LorawanMac
      */
     uint8_t GetNumberOfTransmissions() const;
 
-    /**
-     * Enable data rate adaptation in the retransmitting procedure.
-     *
-     * \param adapt If the data rate adaptation is enabled or not.
-     */
-    void SetADRBackoff(bool adapt);
-
-    /**
-     * Get if data rate adaptation is enabled or not.
-     */
-    bool GetADRBackoff() const;
-
   protected:
     void DoInitialize() override;
     void DoDispose() override;
@@ -459,16 +447,11 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     /**
      * Whether this device's data rate should be controlled by the NS.
      */
-    bool m_ADRBit;
+    bool m_adr;
 
     ////////////////////////////////
     // Private MAC Layer settings //
     ////////////////////////////////
-
-    /**
-     * Enable Data Rate adaptation during the retransmission procedure.
-     */
-    bool m_enableADRBackoff;
 
     /**
      * Whether this device's should use cryptography according to specifications.

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -183,6 +183,26 @@ class BaseEndDeviceLorawanMac : public LorawanMac
      */
     uint8_t GetNumberOfTransmissions() const;
 
+    /**
+     * Get the last known link margin from the demodulation floor.
+     *
+     * This is intended for asynchronous polling by the Application layer of the device. For
+     * synchronous behavior provide a callback using the trace system.
+     *
+     * @return The last known link margin [dB]
+     */
+    uint8_t GetLastKnownLinkMarginDb() const;
+
+    /**
+     * Get the last known number of gateways concurrently receiving transmissions from the device.
+     *
+     * This is intended for asynchronous polling by the Application layer of the device. For
+     * synchronous behavior provide a callback using the trace system.
+     *
+     * @return The last known number of receiver gateways.
+     */
+    uint8_t GetLastKnownGatewayCount() const;
+
   protected:
     void DoInitialize() override;
     void DoDispose() override;
@@ -466,21 +486,21 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     ///////////////////////////////
 
     /**
-     * The last known link margin.
+     * The last known link margin in dB from the demodulation floor.
      *
      * This value is obtained (and updated) when a LinkCheckAns Mac command is
      * received.
      */
-    TracedValue<double> m_lastKnownLinkMargin;
+    TracedValue<uint8_t> m_lastKnownLinkMargin;
 
     /**
      * The last known gateway count (i.e., gateways that are in communication
-     * range with this end device)
+     * range with this end device).
      *
      * This value is obtained (and updated) when a LinkCheckAns Mac command is
      * received.
      */
-    TracedValue<int> m_lastKnownGatewayCount;
+    TracedValue<uint8_t> m_lastKnownGatewayCount;
 
     ///////////////////////
     // Private Utilities //

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -27,7 +27,6 @@
 
 #define ADR_ACK_LIMIT 64
 #define ADR_ACK_DELAY 32
-#define MAX_ADR_ACK_CNT (ADR_ACK_LIMIT + 7 * ADR_ACK_DELAY + 1)
 
 namespace ns3
 {
@@ -254,10 +253,10 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     uint16_t m_fCnt;
 
     /* Counter for keepalive purposes */
-    uint16_t m_ADRACKCnt;
+    uint16_t m_adrAckCnt;
 
     /* Uplink only - request keepalive acknowledgement from the server */
-    bool m_ADRACKReq;
+    bool m_adrAckReq;
 
     /**
      * The event of transmitting a packet in a consecutive moment, when the duty cycle let us

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -390,12 +390,14 @@ class BaseEndDeviceLorawanMac : public LorawanMac
      * \param dataRate The data rate value of the command.
      * \param txPower The transmission power value of the command.
      * \param enabledChannels A list of the enabled channels.
-     * \param repetitions The number of repetitions prescribed by the command.
+     * \param chMaskCntl Indicator of the 16 channel bank to apply the chMask to.
+     * \param nbTrans The number of repetitions prescribed by the command.
      */
     void OnLinkAdrReq(uint8_t dataRate,
                       uint8_t txPower,
                       std::list<int> enabledChannels,
-                      int repetitions);
+                      uint8_t chMaskCntl,
+                      uint8_t nbTrans);
 
     /**
      * Perform the actions that need to be taken when receiving a DutyCycleReq command.

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -392,15 +392,15 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     /**
      * Perform the actions that need to be taken when receiving a LinkAdrReq command.
      *
-     * \param dataRate The data rate value of the command.
-     * \param txPower The transmission power value of the command.
-     * \param enabledChannels A list of the enabled channels.
-     * \param chMaskCntl Indicator of the 16 channel bank to apply the chMask to.
-     * \param nbTrans The number of repetitions prescribed by the command.
+     * @param dataRate The data rate value of the command.
+     * @param txPower The transmission power value of the command.
+     * @param chMask Mask of enabled channels of the command.
+     * @param chMaskCntl Indicator of the 16 channel bank to apply the chMask to.
+     * @param nbTrans The number of repetitions prescribed by the command.
      */
     void OnLinkAdrReq(uint8_t dataRate,
                       uint8_t txPower,
-                      std::list<int> enabledChannels,
+                      uint16_t chMask,
                       uint8_t chMaskCntl,
                       uint8_t nbTrans);
 

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -42,7 +42,7 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     {
         Time firstAttempt;
         Ptr<Packet> packet = nullptr;
-        uint8_t nbTxLeft;
+        uint8_t nbTxLeft = 0;
         bool waitingAck = false;
         bool busy = false;
     };
@@ -182,6 +182,11 @@ class BaseEndDeviceLorawanMac : public LorawanMac
      * Set the maximum number of transmissions allowed.
      */
     uint8_t GetNumberOfTransmissions() const;
+
+    /**
+     * Set the current value of the frame counter.
+     */
+    uint16_t GetFCnt() const;
 
     /**
      * Get the last known link margin from the demodulation floor.

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -46,8 +46,7 @@ ClassAEndDeviceLorawanMac::GetTypeId()
 }
 
 ClassAEndDeviceLorawanMac::ClassAEndDeviceLorawanMac()
-    : m_recvWinSymb(8),
-      // LoRaWAN default
+    : // LoRaWAN default
       m_rx1DrOffset(0),
       m_lastTxCh(nullptr)
 {

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -308,11 +308,11 @@ ClassAEndDeviceLorawanMac::OnRxParamSetupReq(Ptr<RxParamSetupReq> rxParamSetupRe
 }
 
 void
-ClassAEndDeviceLorawanMac::OnRxTimingSetupReq(Time delay)
+ClassAEndDeviceLorawanMac::OnRxTimingSetupReq(uint8_t del)
 {
-    NS_LOG_FUNCTION(this << delay);
+    NS_LOG_FUNCTION(this << unsigned(del));
 
-    m_rwm->SetRx1Delay(delay);
+    m_rwm->SetRx1Delay(Seconds((del) ? del : 1));
 
     NS_LOG_INFO("Adding RxTimingSetupAns reply");
     m_fOpts.emplace_back(Create<RxTimingSetupAns>());

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -67,7 +67,7 @@ ClassAEndDeviceLorawanMac::~ClassAEndDeviceLorawanMac()
 void
 ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packet)
 {
-    NS_LOG_DEBUG("Packet: " << packet);
+    NS_LOG_FUNCTION(this << packet);
 
     // Configure PHY tx params
     m_txParams.sf = GetSfFromDataRate(m_dataRate);
@@ -80,7 +80,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packet)
     // Make sure we can transmit at the current power on this channel
     NS_ASSERT_MSG(m_txPower <= m_channelManager->GetTxPowerForChannel(m_lastTxCh),
                   " The selected power is too hight to be supported by this channel.");
-    NS_LOG_DEBUG("Freq: " << frequency << " Hz");
+    NS_LOG_DEBUG("Freq: " << uint32_t(frequency) << " Hz");
 
     // Tag packet with datarate and frequency
     LoraTag tag;
@@ -91,15 +91,13 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packet)
 
     // Get the duration
     Time duration = m_phy->GetTimeOnAir(packet, m_txParams);
-    NS_LOG_DEBUG("Duration: " << duration.GetSeconds());
+    NS_LOG_DEBUG("Duration: " << duration.As(Time::MS));
     // Add the event to the channelHelper to keep track of duty cycle
     m_channelManager->AddEvent(duration, m_lastTxCh);
 
     // Send the packet to the PHY layer to send it on the channel
     DynamicCast<EndDeviceLoraPhy>(m_phy)->SwitchToStandby();
     m_phy->Send(packet, m_txParams, frequency, m_txPower);
-    // Fire trace source
-    m_sentNewPacket(packet);
 }
 
 void
@@ -212,10 +210,14 @@ ClassAEndDeviceLorawanMac::NoReception()
 void
 ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
 {
+    NS_LOG_FUNCTION(this << outcome);
+
     bool recv = (outcome == RECV || outcome == ACK); // We received something
     bool needAck = m_txContext.waitingAck;           // We were waiting for acknowledgement
     bool gotAck = (outcome == ACK);                  // We got acknowledgement
     bool canReTx = (m_txContext.nbTxLeft > 0 && m_nextTx.IsExpired()); // We can retransmit
+    NS_LOG_DEBUG("recv=" << recv << ",needAck=" << needAck << ",gotAck=" << gotAck
+                         << ",canReTx=" << canReTx);
 
     // Condition to schedule retransmission:
     // either we did not receive or we weren't acknowledged + we can retransmit
@@ -245,7 +247,7 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
     {
         m_requiredTxCallback(txs, true, m_txContext.firstAttempt, m_txContext.packet);
         NS_LOG_DEBUG("Received ACK packet after "
-                     << unsigned(txs) << " transmissions: stopping retransmission procedure. ");
+                     << unsigned(txs) << " transmissions: stopping retransmission procedure");
     }
     // Acknowledgement failure of confirmed txs
     // (either exhausted all reTxs or new pkt scheduled while busy)

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -73,9 +73,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packet)
     m_txParams.sf = GetSfFromDataRate(m_dataRate);
     m_txParams.bandwidthHz = GetBandwidthFromDataRate(m_dataRate);
     m_txParams.lowDataRateOptimizationEnabled = LoraPhy::GetTSym(m_txParams) > MilliSeconds(16);
-    NS_LOG_DEBUG("DR: " << unsigned(m_dataRate));
-    NS_LOG_DEBUG("SF: " << unsigned(m_txParams.sf));
-    NS_LOG_DEBUG("BW: " << m_txParams.bandwidthHz << " Hz");
+    NS_LOG_DEBUG(m_txParams);
 
     m_lastTxCh = GetChannelForTx();
     double frequency = m_lastTxCh->GetFrequency();
@@ -173,7 +171,7 @@ ClassAEndDeviceLorawanMac::Receive(Ptr<const Packet> packet)
     LoraFrameHeader fHdr;
     fHdr.SetAsDownlink();
     int deserialized = packetCopy->RemoveHeader(fHdr);
-    NS_LOG_DEBUG("Deserialized bytes: " << deserialized << ", Frame Header:\n" << fHdr);
+    NS_LOG_DEBUG("Deserialized bytes: " << deserialized << ", Frame Header: " << fHdr);
     // Parse and apply all MAC commands received
     ApplyMACCommands(fHdr, packetCopy);
 
@@ -281,9 +279,9 @@ ClassAEndDeviceLorawanMac::OnRxParamSetupReq(Ptr<RxParamSetupReq> rxParamSetupRe
 
     uint8_t rx1DrOffset = rxParamSetupReq->GetRx1DrOffset();
     uint8_t rx2DataRate = rxParamSetupReq->GetRx2DataRate();
-    double frequency = rxParamSetupReq->GetFrequency();
+    uint32_t frequency = rxParamSetupReq->GetFrequency();
 
-    NS_LOG_INFO(unsigned(rx1DrOffset) << unsigned(rx2DataRate) << frequency);
+    NS_LOG_INFO(unsigned(rx1DrOffset) << " " << unsigned(rx2DataRate) << " " << frequency);
 
     // Check that the desired offset is valid
     bool offsetOk = (0 <= rx1DrOffset && rx1DrOffset <= 5);
@@ -324,17 +322,37 @@ ClassAEndDeviceLorawanMac::OnRxTimingSetupReq(Time delay)
 // Getters and Setters //
 /////////////////////////
 
+uint8_t
+ClassAEndDeviceLorawanMac::GetFirstReceiveWindowDataRate()
+{
+    return m_replyDataRateMatrix.at(m_dataRate).at(m_rx1DrOffset);
+}
+
 void
 ClassAEndDeviceLorawanMac::SetSecondReceiveWindowDataRate(uint8_t dataRate)
 {
+    NS_LOG_FUNCTION(this << unsigned(dataRate));
     m_rwm->SetSf(RecvWindowManager::SECOND, GetSfFromDataRate(dataRate));
     m_rwm->SetDuration(RecvWindowManager::SECOND, GetReceptionWindowDuration(dataRate));
 }
 
-void
-ClassAEndDeviceLorawanMac::SetSecondReceiveWindowFrequency(double frequency)
+uint8_t
+ClassAEndDeviceLorawanMac::GetSecondReceiveWindowDataRate() const
 {
-    m_rwm->SetFrequency(RecvWindowManager::SECOND, frequency);
+    return 12 - m_rwm->GetSf(RecvWindowManager::SECOND);
+}
+
+void
+ClassAEndDeviceLorawanMac::SetSecondReceiveWindowFrequency(uint32_t frequencyHz)
+{
+    NS_LOG_FUNCTION(this << frequencyHz);
+    m_rwm->SetFrequency(RecvWindowManager::SECOND, frequencyHz);
+}
+
+uint32_t
+ClassAEndDeviceLorawanMac::GetSecondReceiveWindowFrequency() const
+{
+    return m_rwm->GetFrequency(RecvWindowManager::SECOND);
 }
 
 void

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -322,6 +322,12 @@ ClassAEndDeviceLorawanMac::OnRxTimingSetupReq(uint8_t del)
 // Getters and Setters //
 /////////////////////////
 
+Time
+ClassAEndDeviceLorawanMac::GetFirstReceiveWindowDelay()
+{
+    return m_rwm->GetRx1Delay();
+}
+
 uint8_t
 ClassAEndDeviceLorawanMac::GetFirstReceiveWindowDataRate()
 {

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -157,8 +157,8 @@ ClassAEndDeviceLorawanMac::Receive(Ptr<const Packet> packet)
     // Open the context to new transmissions
     m_txContext.busy = false;
     // Reset ADR backoff counter and bit
-    m_ADRACKCnt = 0;
-    m_ADRACKReq = false;
+    m_adrAckCnt = 0;
+    m_adrAckReq = false;
     // Clear commands that are re-sent until downlink (DlChannelAns and RxTimingSetupAns)
     m_fOpts.clear();
 
@@ -265,9 +265,9 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
     // Update uplink frame counter
     m_fCnt++;
     // Update ADRACKCnt only if nothing was received
-    if (!recv && m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
+    if (!recv)
     {
-        m_ADRACKCnt++;
+        m_adrAckCnt++;
     }
 }
 

--- a/model/mac/class-a-end-device-lorawan-mac.h
+++ b/model/mac/class-a-end-device-lorawan-mac.h
@@ -85,6 +85,13 @@ class ClassAEndDeviceLorawanMac : public BaseEndDeviceLorawanMac
     /////////////////////////
 
     /**
+     * Get the first receive window opening delay, starting from transmission end.
+     *
+     * @return The first receive window opening delay.
+     */
+    Time GetFirstReceiveWindowDelay();
+
+    /**
      * Get the data rate that will be used in the first receive window.
      *
      * @return The data rate.

--- a/model/mac/class-a-end-device-lorawan-mac.h
+++ b/model/mac/class-a-end-device-lorawan-mac.h
@@ -85,18 +85,39 @@ class ClassAEndDeviceLorawanMac : public BaseEndDeviceLorawanMac
     /////////////////////////
 
     /**
-     * Set the Data Rate to be used in the second receive window.
+     * Get the data rate that will be used in the first receive window.
      *
-     * \param dataRate The Data Rate.
+     * @return The data rate.
+     */
+    uint8_t GetFirstReceiveWindowDataRate();
+
+    /**
+     * Set the data rate to be used in the second receive window.
+     *
+     * @param dataRate The data rate.
      */
     void SetSecondReceiveWindowDataRate(uint8_t dataRate);
 
     /**
+     * Get the data rate that will be used in the second receive window.
+     *
+     * @return The data rate.
+     */
+    uint8_t GetSecondReceiveWindowDataRate() const;
+
+    /**
      * Set the frequency that will be used for the second receive window.
      *
-     * \param frequency the Frequency.
+     * @param frequencyHz The Frequency.
      */
-    void SetSecondReceiveWindowFrequency(double frequency);
+    void SetSecondReceiveWindowFrequency(uint32_t frequencyHz);
+
+    /**
+     * Get the frequency that is used for the second receive window.
+     *
+     * @return The frequency, in Hz.
+     */
+    uint32_t GetSecondReceiveWindowFrequency() const;
 
   protected:
     void DoInitialize() override;

--- a/model/mac/class-a-end-device-lorawan-mac.h
+++ b/model/mac/class-a-end-device-lorawan-mac.h
@@ -167,7 +167,7 @@ class ClassAEndDeviceLorawanMac : public BaseEndDeviceLorawanMac
     /**
      * Perform the actions that need to be taken when receiving a RxTimingSetupReq command.
      */
-    void OnRxTimingSetupReq(Time delay) override;
+    void OnRxTimingSetupReq(uint8_t del) override;
 
     /**
      * The duration of a receive window in number of symbols. This should be

--- a/model/mac/logical-channel-manager.cc
+++ b/model/mac/logical-channel-manager.cc
@@ -104,8 +104,7 @@ LogicalChannelManager::GetSubBandFromFrequency(double frequency)
         }
     }
 
-    NS_LOG_ERROR("Requested frequency: " << frequency);
-    NS_ABORT_MSG("Warning: frequency is outside any known SubBand.");
+    NS_LOG_ERROR("Requested frequency=" << frequency << " is outside any known SubBand.");
 
     return nullptr; // If no SubBand is found, return 0
 }

--- a/model/mac/lora-frame-header.cc
+++ b/model/mac/lora-frame-header.cc
@@ -332,28 +332,23 @@ LoraFrameHeader::Deserialize(Buffer::Iterator start)
 void
 LoraFrameHeader::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "Address=" << m_address.Print() << std::endl;
-    os << "ADR=" << m_adr << std::endl;
-    os << "ADRAckReq=" << m_adrAckReq << std::endl;
-    os << "ACK=" << m_ack << std::endl;
-    os << "FPending=" << m_fPending << std::endl;
-    os << "FOptsLen=" << unsigned(m_fOptsLen) << std::endl;
-    os << "(FRMPCmdsLen=" << unsigned(m_frmpCmdsLen) << ")" << std::endl;
-    os << "FCnt=" << unsigned(m_fCnt) << std::endl;
-
-    for (auto it = m_macCommands.begin(); it != m_macCommands.end(); it++)
+    os << "FHDR(";
+    os << "Address=" << m_address.Print();
+    os << ", ADR=" << m_adr;
+    os << ", ADRAckReq=" << m_adrAckReq;
+    os << ", ACK=" << m_ack;
+    os << ", FPending=" << m_fPending;
+    os << ", FOptsLen=" << unsigned(m_fOptsLen);
+    os << ", FCnt=" << unsigned(m_fCnt);
+    for (const auto& c : m_macCommands)
     {
-        (*it)->Print(os);
+        os << ", ";
+        c->Print(os);
     }
-
     if (m_fPort > -1)
     {
-        os << "FPort=" << m_fPort;
+        os << "), FPort=" << m_fPort;
     }
-
-    os << std::endl;
 }
 
 void

--- a/model/mac/lora-frame-header.cc
+++ b/model/mac/lora-frame-header.cc
@@ -345,9 +345,10 @@ LoraFrameHeader::Print(std::ostream& os) const
         os << ", ";
         c->Print(os);
     }
+    os << ")";
     if (m_fPort > -1)
     {
-        os << "), FPort=" << m_fPort;
+        os << ", FPort=" << m_fPort;
     }
 }
 

--- a/model/mac/lorawan-mac-header.cc
+++ b/model/mac/lorawan-mac-header.cc
@@ -98,8 +98,10 @@ LorawanMacHeader::Deserialize(Buffer::Iterator start)
 void
 LorawanMacHeader::Print(std::ostream& os) const
 {
-    os << "MessageType=" << unsigned(m_ftype) << std::endl;
-    os << "Major=" << unsigned(m_major) << std::endl;
+    os << "MHDR(";
+    os << "MessageType=" << unsigned(m_ftype);
+    os << ", Major=" << unsigned(m_major);
+    os << ")";
 }
 
 void

--- a/model/mac/lorawan-mac.cc
+++ b/model/mac/lorawan-mac.cc
@@ -132,7 +132,7 @@ LorawanMac::GetSfFromDataRate(uint8_t dataRate)
     NS_LOG_FUNCTION(this << unsigned(dataRate));
 
     // Check we are in range
-    if (dataRate >= m_sfForDataRate.size() - 1)
+    if (dataRate > m_sfForDataRate.size() - 1)
     {
         return 0;
     }

--- a/model/mac/lorawan-mac.cc
+++ b/model/mac/lorawan-mac.cc
@@ -132,7 +132,7 @@ LorawanMac::GetSfFromDataRate(uint8_t dataRate)
     NS_LOG_FUNCTION(this << unsigned(dataRate));
 
     // Check we are in range
-    if (dataRate >= m_sfForDataRate.size())
+    if (dataRate >= m_sfForDataRate.size() - 1)
     {
         return 0;
     }
@@ -146,7 +146,7 @@ LorawanMac::GetBandwidthFromDataRate(uint8_t dataRate)
     NS_LOG_FUNCTION(this << unsigned(dataRate));
 
     // Check we are in range
-    if (dataRate > m_bandwidthForDataRate.size())
+    if (dataRate > m_bandwidthForDataRate.size() - 1)
     {
         return 0;
     }
@@ -159,7 +159,7 @@ LorawanMac::GetDbmForTxPower(uint8_t txPower)
 {
     NS_LOG_FUNCTION(this << unsigned(txPower));
 
-    if (txPower > m_txDbmForTxPower.size())
+    if (txPower > m_txDbmForTxPower.size() - 1)
     {
         return -1;
     }

--- a/model/mac/mac-command.cc
+++ b/model/mac/mac-command.cc
@@ -883,11 +883,11 @@ RxTimingSetupReq::RxTimingSetupReq()
     m_serializedSize = 2;
 }
 
-RxTimingSetupReq::RxTimingSetupReq(uint8_t delay)
-    : m_delay(delay)
+RxTimingSetupReq::RxTimingSetupReq(uint8_t del)
+    : m_del(del)
 {
     NS_LOG_FUNCTION(this);
-    NS_ASSERT_MSG(!(delay & 0xF0), "delay field > 4 bits");
+    NS_ASSERT_MSG(!(del & 0xF0), "delay field > 4 bits");
     m_commandType = RX_TIMING_SETUP_REQ;
     m_serializedSize = 2;
 }
@@ -897,15 +897,15 @@ RxTimingSetupReq::Serialize(Buffer::Iterator& start) const
 {
     NS_LOG_FUNCTION(this);
     start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
-    start.WriteU8(m_delay & 0xF);                       // Write the data
+    start.WriteU8(m_del & 0xF);                         // Write the data
 }
 
 uint8_t
 RxTimingSetupReq::Deserialize(Buffer::Iterator& start)
 {
     NS_LOG_FUNCTION(this);
-    start.ReadU8();                 // Consume the CID
-    m_delay = start.ReadU8() & 0xF; // Read the data
+    start.ReadU8();               // Consume the CID
+    m_del = start.ReadU8() & 0xF; // Read the data
     return m_serializedSize;
 }
 
@@ -914,15 +914,15 @@ RxTimingSetupReq::Print(std::ostream& os) const
 {
     NS_LOG_FUNCTION(this);
     os << "RxTimingSetupReq(";
-    os << "Delay=" << Seconds(m_delay).As(Time::S);
+    os << "Del=" << unsigned(m_del);
     os << ")";
 }
 
-Time
-RxTimingSetupReq::GetDelay() const
+uint8_t
+RxTimingSetupReq::GetDel() const
 {
     NS_LOG_FUNCTION(this);
-    return Seconds((m_delay) ? m_delay : 1);
+    return m_del;
 }
 
 //////////////////////

--- a/model/mac/mac-command.cc
+++ b/model/mac/mac-command.cc
@@ -1116,6 +1116,18 @@ DlChannelAns::DlChannelAns(bool uplinkFrequencyExists, bool channelFrequencyOk)
     m_serializedSize = 2;
 }
 
+bool
+DlChannelAns::GetUplinkFrequencyExists() const
+{
+    return m_uplinkFrequencyExists;
+}
+
+bool
+DlChannelAns::GetChannelFrequencyOk() const
+{
+    return m_channelFrequencyOk;
+}
+
 void
 DlChannelAns::Serialize(Buffer::Iterator& start) const
 {

--- a/model/mac/mac-command.cc
+++ b/model/mac/mac-command.cc
@@ -12,10 +12,7 @@
 
 #include "mac-command.h"
 
-#include "ns3/log.h"
-
 #include <bitset>
-#include <cmath>
 
 namespace ns3
 {
@@ -31,22 +28,19 @@ MacCommand::MacCommand()
 
 MacCommand::~MacCommand()
 {
-    NS_LOG_FUNCTION(this);
 }
 
 enum MacCommandType
 MacCommand::GetCommandType() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_commandType;
 }
 
 uint8_t
 MacCommand::GetSerializedSize() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_serializedSize;
 }
 
@@ -54,7 +48,6 @@ uint8_t
 MacCommand::GetCIDFromMacCommand(enum MacCommandType commandType)
 {
     NS_LOG_FUNCTION_NOARGS();
-
     switch (commandType)
     {
     case (INVALID): {
@@ -106,7 +99,7 @@ MacCommand::GetCIDFromMacCommand(enum MacCommandType commandType)
 
 LinkCheckReq::LinkCheckReq()
 {
-    NS_LOG_FUNCTION_NOARGS();
+    NS_LOG_FUNCTION(this);
     m_commandType = LINK_CHECK_REQ;
     m_serializedSize = 1;
 }
@@ -114,31 +107,23 @@ LinkCheckReq::LinkCheckReq()
 void
 LinkCheckReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID and we're done
-    uint8_t cid = GetCIDFromMacCommand(m_commandType);
-    start.WriteU8(cid);
-    NS_LOG_DEBUG("Serialized LinkCheckReq: " << unsigned(cid));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
 }
 
 uint8_t
 LinkCheckReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Read the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     return m_serializedSize;
 }
 
 void
 LinkCheckReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "LinkCheckReq" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "LinkCheckReq()";
 }
 
 //////////////////
@@ -146,11 +131,8 @@ LinkCheckReq::Print(std::ostream& os) const
 //////////////////
 
 LinkCheckAns::LinkCheckAns()
-    : m_margin(0),
-      m_gwCnt(0)
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = LINK_CHECK_ANS;
     m_serializedSize = 3;
 }
@@ -160,7 +142,6 @@ LinkCheckAns::LinkCheckAns(uint8_t margin, uint8_t gwCnt)
       m_gwCnt(gwCnt)
 {
     NS_LOG_FUNCTION(this << unsigned(margin) << unsigned(gwCnt));
-
     m_commandType = LINK_CHECK_ANS;
     m_serializedSize = 3;
 }
@@ -168,23 +149,17 @@ LinkCheckAns::LinkCheckAns(uint8_t margin, uint8_t gwCnt)
 void
 LinkCheckAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-    // Write the margin
-    start.WriteU8(m_margin);
-    // Write the gwCnt
-    start.WriteU8(m_gwCnt);
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
+    start.WriteU8(m_margin);                            // Write the margin
+    start.WriteU8(m_gwCnt);                             // Write the gwCnt
 }
 
 uint8_t
 LinkCheckAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     m_margin = start.ReadU8();
     m_gwCnt = start.ReadU8();
     return m_serializedSize;
@@ -193,35 +168,18 @@ LinkCheckAns::Deserialize(Buffer::Iterator& start)
 void
 LinkCheckAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "LinkCheckAns" << std::endl;
-    os << "margin: " << unsigned(m_margin) << std::endl;
-    os << "gwCnt: " << unsigned(m_gwCnt) << std::endl;
-}
-
-void
-LinkCheckAns::SetMargin(uint8_t margin)
-{
-    NS_LOG_FUNCTION(this << unsigned(margin));
-
-    m_margin = margin;
+    NS_LOG_FUNCTION(this);
+    os << "LinkCheckAns(";
+    os << "Margin=" << unsigned(m_margin);
+    os << ", GwCnt=" << unsigned(m_gwCnt);
+    os << ")";
 }
 
 uint8_t
 LinkCheckAns::GetMargin() const
 {
     NS_LOG_FUNCTION(this);
-
     return m_margin;
-}
-
-void
-LinkCheckAns::SetGwCnt(uint8_t gwCnt)
-{
-    NS_LOG_FUNCTION(this << unsigned(gwCnt));
-
-    m_gwCnt = gwCnt;
 }
 
 uint8_t
@@ -230,14 +188,6 @@ LinkCheckAns::GetGwCnt() const
     NS_LOG_FUNCTION(this);
 
     return m_gwCnt;
-}
-
-void
-LinkCheckAns::IncrementGwCnt()
-{
-    NS_LOG_FUNCTION(this);
-
-    m_gwCnt++;
 }
 
 ////////////////
@@ -351,7 +301,6 @@ LinkAdrReq::GetNbTrans() const
 LinkAdrAns::LinkAdrAns()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = LINK_ADR_ANS;
     m_serializedSize = 2;
 }
@@ -362,7 +311,6 @@ LinkAdrAns::LinkAdrAns(bool powerAck, bool dataRateAck, bool channelMaskAck)
       m_channelMaskAck(channelMaskAck)
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = LINK_ADR_ANS;
     m_serializedSize = 2;
 }
@@ -370,12 +318,8 @@ LinkAdrAns::LinkAdrAns(bool powerAck, bool dataRateAck, bool channelMaskAck)
 void
 LinkAdrAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-    // We can assume that true will be converted to 1 and that false will be
-    // converted to 0 on any C++ compiler
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8((uint8_t(m_powerAck) << 2) | (uint8_t(m_dataRateAck) << 1) |
                   uint8_t(m_channelMaskAck));
 }
@@ -383,26 +327,45 @@ LinkAdrAns::Serialize(Buffer::Iterator& start) const
 uint8_t
 LinkAdrAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     uint8_t byte = start.ReadU8();
-
     m_powerAck = byte & 0b100;
     m_dataRateAck = byte & 0b10;
     m_channelMaskAck = byte & 0b1;
-
     return m_serializedSize;
 }
 
 void
 LinkAdrAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
+    NS_LOG_FUNCTION(this);
+    os << "LinkAdrAns(";
+    os << "PowerACK=" << m_powerAck;
+    os << ", DataRateACK=" << m_dataRateAck;
+    os << ", ChannelMaskACK=" << m_channelMaskAck;
+    os << ")";
+}
 
-    os << "LinkAdrAns" << std::endl;
+bool
+LinkAdrAns::GetPowerAck() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_powerAck;
+}
+
+bool
+LinkAdrAns::GetDataRateAck() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_dataRateAck;
+}
+
+bool
+LinkAdrAns::GetChannelMaskAck() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_channelMaskAck;
 }
 
 //////////////////
@@ -412,16 +375,15 @@ LinkAdrAns::Print(std::ostream& os) const
 DutyCycleReq::DutyCycleReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DUTY_CYCLE_REQ;
     m_serializedSize = 2;
 }
 
-DutyCycleReq::DutyCycleReq(uint8_t dutyCycle)
-    : m_maxDCycle(dutyCycle)
+DutyCycleReq::DutyCycleReq(uint8_t maxDutyCycle)
 {
-    NS_LOG_FUNCTION(this);
-
+    NS_LOG_FUNCTION(this << unsigned(maxDutyCycle));
+    NS_ASSERT_MSG(!(maxDutyCycle & 0xF0), "maxDutyCycle > 4 bits");
+    m_maxDutyCycle = maxDutyCycle;
     m_commandType = DUTY_CYCLE_REQ;
     m_serializedSize = 2;
 }
@@ -429,52 +391,34 @@ DutyCycleReq::DutyCycleReq(uint8_t dutyCycle)
 void
 DutyCycleReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-    start.WriteU8(m_maxDCycle);
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
+    start.WriteU8(m_maxDutyCycle);
 }
 
 uint8_t
 DutyCycleReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    m_maxDCycle = start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
+    m_maxDutyCycle = start.ReadU8();
     return m_serializedSize;
 }
 
 void
 DutyCycleReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "DutyCycleReq" << std::endl;
-    os << "maxDCycle: " << unsigned(m_maxDCycle) << std::endl;
-    os << "maxDCycle (fraction): " << GetMaximumAllowedDutyCycle() << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "DutyCycleReq(";
+    os << "MaxDutyCycle=" << unsigned(m_maxDutyCycle);
+    os << ")";
 }
 
 double
-DutyCycleReq::GetMaximumAllowedDutyCycle() const
+DutyCycleReq::GetMaxDutyCycle() const
 {
     NS_LOG_FUNCTION(this);
-
-    // Check if we need to turn off completely
-    if (m_maxDCycle == 255)
-    {
-        return 0;
-    }
-
-    if (m_maxDCycle == 0)
-    {
-        return 1;
-    }
-
-    return 1 / std::pow(2, double(m_maxDCycle));
+    return (m_maxDutyCycle) ? 1 / std::pow(2, double(m_maxDutyCycle)) : 1;
 }
 
 //////////////////
@@ -484,7 +428,6 @@ DutyCycleReq::GetMaximumAllowedDutyCycle() const
 DutyCycleAns::DutyCycleAns()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DUTY_CYCLE_ANS;
     m_serializedSize = 1;
 }
@@ -492,60 +435,44 @@ DutyCycleAns::DutyCycleAns()
 void
 DutyCycleAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
 }
 
 uint8_t
 DutyCycleAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     return m_serializedSize;
 }
 
 void
 DutyCycleAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "DutyCycleAns" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "DutyCycleAns()";
 }
 
-//////////////////
+/////////////////////
 // RxParamSetupReq //
-//////////////////
+/////////////////////
 
 RxParamSetupReq::RxParamSetupReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = RX_PARAM_SETUP_REQ;
     m_serializedSize = 5;
 }
 
-RxParamSetupReq::RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency)
+RxParamSetupReq::RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, uint32_t frequencyHz)
     : m_rx1DrOffset(rx1DrOffset),
       m_rx2DataRate(rx2DataRate),
-      m_frequency(frequency)
+      m_frequencyHz(frequencyHz)
 {
-    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate) << frequency);
-
-    if ((rx1DrOffset & 0b11111000) != 0)
-    {
-        NS_LOG_WARN(
-            "Warning: received an rx1DrOffset greater than 7. Actual value will be different.");
-    }
-    if ((rx2DataRate & 0b11110000) != 0)
-    {
-        NS_LOG_WARN(
-            "Warning: received a rx2DataRate greater than 15. Actual value will be different.");
-    }
-
+    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate) << frequencyHz);
+    NS_ASSERT_MSG(!(rx1DrOffset & 0xF8), "rx1DrOffset > 3 bits");
+    NS_ASSERT_MSG(!(rx2DataRate & 0xF0), "rx2DataRate > 4 bits");
     m_commandType = RX_PARAM_SETUP_REQ;
     m_serializedSize = 5;
 }
@@ -553,57 +480,48 @@ RxParamSetupReq::RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, doubl
 void
 RxParamSetupReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-    // Data serialization
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8((m_rx1DrOffset & 0b111) << 4 | (m_rx2DataRate & 0b1111));
-    auto encodedFrequency = uint32_t(m_frequency / 100);
-    NS_LOG_DEBUG(unsigned(encodedFrequency));
-    NS_LOG_DEBUG(std::bitset<32>(encodedFrequency));
-    start.WriteU8((encodedFrequency & 0xff0000) >> 16); // Most significant byte
-    start.WriteU8((encodedFrequency & 0xff00) >> 8);    // Middle byte
-    start.WriteU8(encodedFrequency & 0xff);             // Least significant byte
+    uint32_t encodedFrequency = m_frequencyHz / 100;
+    // Frequency is in little endian (lsb -> msb)
+    start.WriteU8(encodedFrequency);       // Least significant byte
+    start.WriteU8(encodedFrequency >> 8);  // Middle byte
+    start.WriteU8(encodedFrequency >> 16); // Most significant byte
 }
 
 uint8_t
 RxParamSetupReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    // Data serialization
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     uint8_t firstByte = start.ReadU8();
     m_rx1DrOffset = (firstByte & 0b1110000) >> 4;
     m_rx2DataRate = firstByte & 0b1111;
-    uint32_t secondByte = start.ReadU8();
-    uint32_t thirdByte = start.ReadU8();
-    uint32_t fourthByte = start.ReadU8();
-    uint32_t encodedFrequency = (fourthByte << 16) | (thirdByte << 8) | secondByte;
-    NS_LOG_DEBUG(std::bitset<32>(encodedFrequency));
-    m_frequency = double(encodedFrequency) * 100;
-
+    uint32_t encodedFrequency = 0;
+    // Frequency is in little endian (lsb -> msb)
+    encodedFrequency += start.ReadU8();       // Least significant byte
+    encodedFrequency += start.ReadU8() << 8;  // Middle byte
+    encodedFrequency += start.ReadU8() << 16; // Most significant byte
+    m_frequencyHz = encodedFrequency * 100;
     return m_serializedSize;
 }
 
 void
 RxParamSetupReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "RxParamSetupReq" << std::endl;
-    os << "rx1DrOffset: " << unsigned(m_rx1DrOffset) << std::endl;
-    os << "rx2DataRate: " << unsigned(m_rx2DataRate) << std::endl;
-    os << "frequency: " << m_frequency << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "RxParamSetupReq(";
+    os << "RX1DROffset=" << unsigned(m_rx1DrOffset);
+    os << ", RX2DataRate=" << unsigned(m_rx2DataRate);
+    os << ", Frequency=" << m_frequencyHz;
+    os << ")";
 }
 
 uint8_t
 RxParamSetupReq::GetRx1DrOffset()
 {
     NS_LOG_FUNCTION(this);
-
     return m_rx1DrOffset;
 }
 
@@ -611,16 +529,14 @@ uint8_t
 RxParamSetupReq::GetRx2DataRate()
 {
     NS_LOG_FUNCTION(this);
-
     return m_rx2DataRate;
 }
 
-double
+uint32_t
 RxParamSetupReq::GetFrequency()
 {
     NS_LOG_FUNCTION(this);
-
-    return m_frequency;
+    return m_frequencyHz;
 }
 
 /////////////////////
@@ -630,7 +546,6 @@ RxParamSetupReq::GetFrequency()
 RxParamSetupAns::RxParamSetupAns()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = RX_PARAM_SETUP_ANS;
     m_serializedSize = 2;
 }
@@ -641,7 +556,6 @@ RxParamSetupAns::RxParamSetupAns(bool rx1DrOffsetAck, bool rx2DataRateAck, bool 
       m_channelAck(channelAck)
 {
     NS_LOG_FUNCTION(this << rx1DrOffsetAck << rx2DataRateAck << channelAck);
-
     m_commandType = RX_PARAM_SETUP_ANS;
     m_serializedSize = 2;
 }
@@ -649,11 +563,8 @@ RxParamSetupAns::RxParamSetupAns(bool rx1DrOffsetAck, bool rx2DataRateAck, bool 
 void
 RxParamSetupAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-    // Data serialization
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8(uint8_t(m_rx1DrOffsetAck) << 2 | uint8_t(m_rx2DataRateAck) << 1 |
                   uint8_t(m_channelAck));
 }
@@ -661,29 +572,45 @@ RxParamSetupAns::Serialize(Buffer::Iterator& start) const
 uint8_t
 RxParamSetupAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     uint8_t byte = start.ReadU8();
-
     m_rx1DrOffsetAck = (byte & 0b100) >> 2;
     m_rx2DataRateAck = (byte & 0b10) >> 1;
     m_channelAck = byte & 0b1;
-
     return m_serializedSize;
 }
 
 void
 RxParamSetupAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
+    NS_LOG_FUNCTION(this);
+    os << "RxParamSetupAns(";
+    os << "RX1DROffsetACK=" << m_rx1DrOffsetAck;
+    os << ", RX2DataRateACK=" << m_rx2DataRateAck;
+    os << ", ChannelACK=" << m_channelAck;
+    os << ")";
+}
 
-    os << "RxParamSetupAns" << std::endl;
-    os << "m_rx1DrOffsetAck: " << m_rx1DrOffsetAck << std::endl;
-    os << "m_rx2DataRateAck: " << m_rx2DataRateAck << std::endl;
-    os << "m_channelAck: " << m_channelAck << std::endl;
+bool
+RxParamSetupAns::GetRx1DrOffsetAck() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_rx1DrOffsetAck;
+}
+
+bool
+RxParamSetupAns::GetRx2DataRateAck() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_rx2DataRateAck;
+}
+
+bool
+RxParamSetupAns::GetChannelAck() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_channelAck;
 }
 
 //////////////////
@@ -693,7 +620,6 @@ RxParamSetupAns::Print(std::ostream& os) const
 DevStatusReq::DevStatusReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DEV_STATUS_REQ;
     m_serializedSize = 1;
 }
@@ -701,29 +627,23 @@ DevStatusReq::DevStatusReq()
 void
 DevStatusReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
 }
 
 uint8_t
 DevStatusReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     return m_serializedSize;
 }
 
 void
 DevStatusReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "DevStatusReq" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "DevStatusReq()";
 }
 
 //////////////////
@@ -733,7 +653,6 @@ DevStatusReq::Print(std::ostream& os) const
 DevStatusAns::DevStatusAns()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DEV_STATUS_ANS;
     m_serializedSize = 3;
 }
@@ -743,7 +662,7 @@ DevStatusAns::DevStatusAns(uint8_t battery, uint8_t margin)
       m_margin(margin)
 {
     NS_LOG_FUNCTION(this << unsigned(battery) << unsigned(margin));
-
+    NS_ASSERT_MSG(!(margin & 0xC0), "margin > 6 bits");
     m_commandType = DEV_STATUS_ANS;
     m_serializedSize = 3;
 }
@@ -751,10 +670,8 @@ DevStatusAns::DevStatusAns(uint8_t battery, uint8_t margin)
 void
 DevStatusAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8(m_battery);
     start.WriteU8(m_margin);
 }
@@ -762,39 +679,34 @@ DevStatusAns::Serialize(Buffer::Iterator& start) const
 uint8_t
 DevStatusAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     m_battery = start.ReadU8();
-    m_margin = start.ReadU8() & 0b111111;
-
+    m_margin = start.ReadU8();
     return m_serializedSize;
 }
 
 void
 DevStatusAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "DevStatusAns" << std::endl;
-    os << "Battery: " << unsigned(m_battery) << std::endl;
-    os << "Margin: " << unsigned(m_margin) << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "DevStatusAns(";
+    os << "Battery=" << unsigned(m_battery);
+    os << ", Margin=" << unsigned(m_margin);
+    os << ")";
 }
 
 uint8_t
 DevStatusAns::GetBattery() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_battery;
 }
 
 uint8_t
 DevStatusAns::GetMargin() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_margin;
 }
 
@@ -805,22 +717,22 @@ DevStatusAns::GetMargin() const
 NewChannelReq::NewChannelReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = NEW_CHANNEL_REQ;
     m_serializedSize = 6;
 }
 
 NewChannelReq::NewChannelReq(uint8_t chIndex,
-                             double frequency,
+                             uint32_t frequencyHz,
                              uint8_t minDataRate,
                              uint8_t maxDataRate)
     : m_chIndex(chIndex),
-      m_frequency(frequency),
+      m_frequencyHz(frequencyHz),
       m_minDataRate(minDataRate),
       m_maxDataRate(maxDataRate)
 {
     NS_LOG_FUNCTION(this);
-
+    NS_ASSERT_MSG(!(minDataRate & 0xF0), "minDataRate > 4 bits");
+    NS_ASSERT_MSG(!(maxDataRate & 0xF0), "maxDataRate > 4 bits");
     m_commandType = NEW_CHANNEL_REQ;
     m_serializedSize = 6;
 }
@@ -828,82 +740,72 @@ NewChannelReq::NewChannelReq(uint8_t chIndex,
 void
 NewChannelReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8(m_chIndex);
-    auto encodedFrequency = uint32_t(m_frequency / 100);
-    start.WriteU8((encodedFrequency & 0xff0000) >> 16);
-    start.WriteU8((encodedFrequency & 0xff00) >> 8);
-    start.WriteU8(encodedFrequency & 0xff);
+    uint32_t encodedFrequency = m_frequencyHz / 100;
+    // Frequency is in little endian (lsb -> msb)
+    start.WriteU8(encodedFrequency);       // Least significant byte
+    start.WriteU8(encodedFrequency >> 8);  // Middle byte
+    start.WriteU8(encodedFrequency >> 16); // Most significant byte
     start.WriteU8((m_maxDataRate << 4) | (m_minDataRate & 0xf));
 }
 
 uint8_t
 NewChannelReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    // Read the data
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     m_chIndex = start.ReadU8();
     uint32_t encodedFrequency = 0;
-    // Frequency is in big endian
-    encodedFrequency |= uint32_t(start.ReadU8());
-    encodedFrequency |= uint32_t(start.ReadU8()) << 8;
-    encodedFrequency |= uint32_t(start.ReadU8()) << 16;
-    m_frequency = double(encodedFrequency) * 100;
+    // Frequency is in little endian (lsb -> msb)
+    encodedFrequency += start.ReadU8();       // Least significant byte
+    encodedFrequency += start.ReadU8() << 8;  // Middle byte
+    encodedFrequency += start.ReadU8() << 16; // Most significant byte
+    m_frequencyHz = encodedFrequency * 100;
     uint8_t dataRateByte = start.ReadU8();
     m_maxDataRate = dataRateByte >> 4;
     m_minDataRate = dataRateByte & 0xf;
-
     return m_serializedSize;
 }
 
 void
 NewChannelReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "NewChannelReq" << std::endl;
-    os << "ChIndex: " << (unsigned)m_chIndex << std::endl;
-    os << "Frequency: " << m_frequency << std::endl;
-    os << "MaxDR: " << (unsigned)m_maxDataRate << std::endl;
-    os << "MinDR: " << (unsigned)m_minDataRate << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "NewChannelReq(";
+    os << "ChIndex=" << unsigned(m_chIndex);
+    os << ", Frequency=" << uint32_t(m_frequencyHz);
+    os << ", MaxDR=" << unsigned(m_maxDataRate);
+    os << ", MinDR=" << unsigned(m_minDataRate);
+    os << ")";
 }
 
 uint8_t
 NewChannelReq::GetChannelIndex() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_chIndex;
 }
 
-double
+uint32_t
 NewChannelReq::GetFrequency() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    return m_frequency;
+    NS_LOG_FUNCTION(this);
+    return m_frequencyHz;
 }
 
 uint8_t
 NewChannelReq::GetMinDataRate() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_minDataRate;
 }
 
 uint8_t
 NewChannelReq::GetMaxDataRate() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_maxDataRate;
 }
 
@@ -914,7 +816,6 @@ NewChannelReq::GetMaxDataRate() const
 NewChannelAns::NewChannelAns()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = NEW_CHANNEL_ANS;
     m_serializedSize = 2;
 }
@@ -924,7 +825,6 @@ NewChannelAns::NewChannelAns(bool dataRateRangeOk, bool channelFrequencyOk)
       m_channelFrequencyOk(channelFrequencyOk)
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = NEW_CHANNEL_ANS;
     m_serializedSize = 2;
 }
@@ -932,37 +832,44 @@ NewChannelAns::NewChannelAns(bool dataRateRangeOk, bool channelFrequencyOk)
 void
 NewChannelAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8((uint8_t(m_dataRateRangeOk) << 1) | uint8_t(m_channelFrequencyOk));
 }
 
 uint8_t
 NewChannelAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    // Read the data
-    uint8_t byte = start.ReadU8();
+    NS_LOG_FUNCTION(this);
+    start.ReadU8();                // Consume the CID
+    uint8_t byte = start.ReadU8(); // Read the data
     m_dataRateRangeOk = (byte & 0b10) >> 1;
     m_channelFrequencyOk = (byte & 0b1);
-
     return m_serializedSize;
 }
 
 void
 NewChannelAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
+    NS_LOG_FUNCTION(this);
+    os << "NewChannelAns(";
+    os << "DataRateRangeOk=" << m_dataRateRangeOk;
+    os << ", ChannelFrequencyOk=" << m_channelFrequencyOk;
+    os << ")";
+}
 
-    os << "NewChannelAns" << std::endl;
-    os << "DataRateRangeOk: " << m_dataRateRangeOk << std::endl;
-    os << "ChannelFrequencyOk: " << m_channelFrequencyOk << std::endl;
+bool
+NewChannelAns::GetDataRateRangeOk() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_dataRateRangeOk;
+}
+
+bool
+NewChannelAns::GetChannelFrequencyOk() const
+{
+    NS_LOG_FUNCTION(this);
+    return m_channelFrequencyOk;
 }
 
 //////////////////////
@@ -972,7 +879,6 @@ NewChannelAns::Print(std::ostream& os) const
 RxTimingSetupReq::RxTimingSetupReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = RX_TIMING_SETUP_REQ;
     m_serializedSize = 2;
 }
@@ -981,7 +887,7 @@ RxTimingSetupReq::RxTimingSetupReq(uint8_t delay)
     : m_delay(delay)
 {
     NS_LOG_FUNCTION(this);
-
+    NS_ASSERT_MSG(!(delay & 0xF0), "delay field > 4 bits");
     m_commandType = RX_TIMING_SETUP_REQ;
     m_serializedSize = 2;
 }
@@ -989,162 +895,133 @@ RxTimingSetupReq::RxTimingSetupReq(uint8_t delay)
 void
 RxTimingSetupReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-    // Write the data
-    start.WriteU8(m_delay & 0xf);
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
+    start.WriteU8(m_delay & 0xF);                       // Write the data
 }
 
 uint8_t
 RxTimingSetupReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    // Read the data
-    m_delay = start.ReadU8() & 0xf;
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8();                 // Consume the CID
+    m_delay = start.ReadU8() & 0xF; // Read the data
     return m_serializedSize;
 }
 
 void
 RxTimingSetupReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "RxTimingSetupReq" << std::endl;
-    os << "Delay: " << unsigned((m_delay) ? m_delay : 1) << "s" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "RxTimingSetupReq(";
+    os << "Delay=" << Seconds(m_delay).As(Time::S);
+    os << ")";
 }
 
 Time
-RxTimingSetupReq::GetDelay()
+RxTimingSetupReq::GetDelay() const
 {
     NS_LOG_FUNCTION(this);
-
     return Seconds((m_delay) ? m_delay : 1);
 }
 
-//////////////////
+//////////////////////
 // RxTimingSetupAns //
-//////////////////
+//////////////////////
 
 RxTimingSetupAns::RxTimingSetupAns()
 {
     NS_LOG_FUNCTION(this);
-
-    m_commandType = DEV_STATUS_REQ;
+    m_commandType = RX_TIMING_SETUP_ANS;
     m_serializedSize = 1;
 }
 
 void
 RxTimingSetupAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
 }
 
 uint8_t
 RxTimingSetupAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     return m_serializedSize;
 }
 
 void
 RxTimingSetupAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "RxTimingSetupAns" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "RxTimingSetupAns()";
 }
 
-//////////////////
+/////////////////////
 // TxParamSetupReq //
-//////////////////
+/////////////////////
 
 TxParamSetupReq::TxParamSetupReq()
 {
     NS_LOG_FUNCTION(this);
-
-    m_commandType = DEV_STATUS_REQ;
+    m_commandType = TX_PARAM_SETUP_REQ;
     m_serializedSize = 2;
 }
 
 void
 TxParamSetupReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
 }
 
 uint8_t
 TxParamSetupReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     return m_serializedSize;
 }
 
 void
 TxParamSetupReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "TxParamSetupReq" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "TxParamSetupReq()";
 }
 
-//////////////////
+/////////////////////
 // TxParamSetupAns //
-//////////////////
+/////////////////////
 
 TxParamSetupAns::TxParamSetupAns()
 {
     NS_LOG_FUNCTION(this);
-
-    m_commandType = DEV_STATUS_REQ;
+    m_commandType = TX_PARAM_SETUP_ANS;
     m_serializedSize = 1;
 }
 
 void
 TxParamSetupAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
 }
 
 uint8_t
 TxParamSetupAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     return m_serializedSize;
 }
 
 void
 TxParamSetupAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "TxParamSetupAns" << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "TxParamSetupAns()";
 }
 
 //////////////////
@@ -1154,17 +1031,15 @@ TxParamSetupAns::Print(std::ostream& os) const
 DlChannelReq::DlChannelReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DL_CHANNEL_REQ;
     m_serializedSize = 5;
 }
 
-DlChannelReq::DlChannelReq(uint8_t chIndex, double frequency)
+DlChannelReq::DlChannelReq(uint8_t chIndex, uint32_t frequencyHz)
     : m_chIndex(chIndex),
-      m_frequency(frequency)
+      m_frequencyHz(frequencyHz)
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DL_CHANNEL_REQ;
     m_serializedSize = 5;
 }
@@ -1172,61 +1047,53 @@ DlChannelReq::DlChannelReq(uint8_t chIndex, double frequency)
 void
 DlChannelReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8(m_chIndex);
-    auto encodedFrequency = uint32_t(m_frequency / 100);
-    start.WriteU8((encodedFrequency & 0xff0000) >> 16);
-    start.WriteU8((encodedFrequency & 0xff00) >> 8);
-    start.WriteU8(encodedFrequency & 0xff);
+    uint32_t encodedFrequency = m_frequencyHz / 100;
+    // Frequency is in little endian (lsb -> msb)
+    start.WriteU8(encodedFrequency);       // Least significant byte
+    start.WriteU8(encodedFrequency >> 8);  // Middle byte
+    start.WriteU8(encodedFrequency >> 16); // Most significant byte
 }
 
 uint8_t
 DlChannelReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    // Read the data
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     m_chIndex = start.ReadU8();
     uint32_t encodedFrequency = 0;
-    // Frequency is in big endian
-    encodedFrequency |= uint32_t(start.ReadU8());
-    encodedFrequency |= uint32_t(start.ReadU8()) << 8;
-    encodedFrequency |= uint32_t(start.ReadU8()) << 16;
-    m_frequency = double(encodedFrequency) * 100;
-
+    // Frequency is in little endian (lsb -> msb)
+    encodedFrequency += start.ReadU8();       // Least significant byte
+    encodedFrequency += start.ReadU8() << 8;  // Middle byte
+    encodedFrequency += start.ReadU8() << 16; // Most significant byte
+    m_frequencyHz = encodedFrequency * 100;
     return m_serializedSize;
 }
 
 void
 DlChannelReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "DlChannelReq" << std::endl;
-    os << "ChIndex: " << (unsigned)m_chIndex << std::endl;
-    os << "Frequency: " << m_frequency << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "DlChannelReq(";
+    os << "ChIndex=" << unsigned(m_chIndex);
+    os << ", Frequency=" << uint32_t(m_frequencyHz);
+    os << ")";
 }
 
 uint8_t
 DlChannelReq::GetChannelIndex() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
+    NS_LOG_FUNCTION(this);
     return m_chIndex;
 }
 
-double
+uint32_t
 DlChannelReq::GetFrequency() const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    return m_frequency;
+    NS_LOG_FUNCTION(this);
+    return m_frequencyHz;
 }
 
 //////////////////
@@ -1236,7 +1103,6 @@ DlChannelReq::GetFrequency() const
 DlChannelAns::DlChannelAns()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DL_CHANNEL_ANS;
     m_serializedSize = 2;
 }
@@ -1246,7 +1112,6 @@ DlChannelAns::DlChannelAns(bool uplinkFrequencyExists, bool channelFrequencyOk)
       m_channelFrequencyOk(channelFrequencyOk)
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = DL_CHANNEL_ANS;
     m_serializedSize = 2;
 }
@@ -1254,37 +1119,30 @@ DlChannelAns::DlChannelAns(bool uplinkFrequencyExists, bool channelFrequencyOk)
 void
 DlChannelAns::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
-
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8((uint8_t(m_uplinkFrequencyExists) << 1) | uint8_t(m_channelFrequencyOk));
 }
 
 uint8_t
 DlChannelAns::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
-    // Read the data
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     uint8_t byte = start.ReadU8();
     m_uplinkFrequencyExists = (byte & 0b10) >> 1;
     m_channelFrequencyOk = (byte & 0b1);
-
     return m_serializedSize;
 }
 
 void
 DlChannelAns::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "DlChannelAns" << std::endl;
-    os << "UplinkFrequencyExists: " << m_uplinkFrequencyExists << std::endl;
-    os << "ChannelFrequencyOk: " << m_channelFrequencyOk << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "DlChannelAns(";
+    os << "UplinkFrequencyExists=" << m_uplinkFrequencyExists;
+    os << ", ChannelFrequencyOk=" << m_channelFrequencyOk;
+    os << ")";
 }
 
 } // namespace lorawan

--- a/model/mac/mac-command.cc
+++ b/model/mac/mac-command.cc
@@ -247,24 +247,26 @@ LinkCheckAns::IncrementGwCnt()
 LinkAdrReq::LinkAdrReq()
 {
     NS_LOG_FUNCTION(this);
-
     m_commandType = LINK_ADR_REQ;
     m_serializedSize = 5;
 }
 
 LinkAdrReq::LinkAdrReq(uint8_t dataRate,
                        uint8_t txPower,
-                       uint16_t channelMask,
+                       uint16_t chMask,
                        uint8_t chMaskCntl,
-                       uint8_t nbRep)
+                       uint8_t nbTrans)
     : m_dataRate(dataRate),
       m_txPower(txPower),
-      m_channelMask(channelMask),
+      m_chMask(chMask),
       m_chMaskCntl(chMaskCntl),
-      m_nbRep(nbRep)
+      m_nbTrans(nbTrans)
 {
     NS_LOG_FUNCTION(this);
-
+    NS_ASSERT_MSG(!(dataRate & 0xF0), "dataRate field > 4 bits");
+    NS_ASSERT_MSG(!(txPower & 0xF0), "txPower field > 4 bits");
+    NS_ASSERT_MSG(!(chMaskCntl & 0xF8), "chMaskCntl field > 3 bits");
+    NS_ASSERT_MSG(!(nbTrans & 0xF0), "nbTrans field > 4 bits");
     m_commandType = LINK_ADR_REQ;
     m_serializedSize = 5;
 }
@@ -272,93 +274,74 @@ LinkAdrReq::LinkAdrReq(uint8_t dataRate,
 void
 LinkAdrReq::Serialize(Buffer::Iterator& start) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Write the CID
-    start.WriteU8(GetCIDFromMacCommand(m_commandType));
+    NS_LOG_FUNCTION(this);
+    start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8(m_dataRate << 4 | (m_txPower & 0b1111));
-    start.WriteU16(m_channelMask);
-    start.WriteU8(m_chMaskCntl << 4 | (m_nbRep & 0b1111));
+    start.WriteU16(m_chMask);
+    start.WriteU8(m_chMaskCntl << 4 | (m_nbTrans & 0b1111));
 }
 
 uint8_t
 LinkAdrReq::Deserialize(Buffer::Iterator& start)
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    // Consume the CID
-    start.ReadU8();
+    NS_LOG_FUNCTION(this);
+    start.ReadU8(); // Consume the CID
     uint8_t firstByte = start.ReadU8();
     m_dataRate = firstByte >> 4;
     m_txPower = firstByte & 0b1111;
-    m_channelMask = start.ReadU16();
+    m_chMask = start.ReadU16();
     uint8_t fourthByte = start.ReadU8();
     m_chMaskCntl = fourthByte >> 4;
-    m_nbRep = fourthByte & 0b1111;
-
+    m_nbTrans = fourthByte & 0b1111;
     return m_serializedSize;
 }
 
 void
 LinkAdrReq::Print(std::ostream& os) const
 {
-    NS_LOG_FUNCTION_NOARGS();
-
-    os << "LinkAdrReq" << std::endl;
-    os << "dataRate: " << unsigned(m_dataRate) << std::endl;
-    os << "txPower: " << unsigned(m_txPower) << std::endl;
-    os << "channelMask: " << std::bitset<16>(m_channelMask) << std::endl;
-    os << "chMaskCntl: " << unsigned(m_chMaskCntl) << std::endl;
-    os << "nbRep: " << unsigned(m_nbRep) << std::endl;
+    NS_LOG_FUNCTION(this);
+    os << "LinkAdrReq(";
+    os << "DataRate=" << unsigned(m_dataRate);
+    os << ", TXPower=" << unsigned(m_txPower);
+    os << ", ChMask=" << std::bitset<16>(m_chMask);
+    os << ", ChMaskCntl=" << unsigned(m_chMaskCntl);
+    os << ", NbTrans=" << unsigned(m_nbTrans);
+    os << ")";
 }
 
 uint8_t
-LinkAdrReq::GetDataRate()
+LinkAdrReq::GetDataRate() const
 {
     NS_LOG_FUNCTION(this);
-
     return m_dataRate;
 }
 
 uint8_t
-LinkAdrReq::GetTxPower()
+LinkAdrReq::GetTxPower() const
 {
     NS_LOG_FUNCTION(this);
-
     return m_txPower;
 }
 
-std::list<int>
-LinkAdrReq::GetEnabledChannelsList()
+uint16_t
+LinkAdrReq::GetChMask() const
 {
     NS_LOG_FUNCTION(this);
-
-    std::list<int> channelIndices;
-    for (int i = 0; i < 16; i++)
-    {
-        if (m_channelMask & (0b1 << i)) // Take channel mask's i-th bit
-        {
-            NS_LOG_DEBUG("Adding channel index " << i);
-            channelIndices.push_back(i);
-        }
-    }
-
-    return channelIndices;
+    return m_chMask;
 }
 
 uint8_t
-LinkAdrReq::GetChMaskCntl()
+LinkAdrReq::GetChMaskCntl() const
 {
     NS_LOG_FUNCTION(this);
     return m_chMaskCntl;
 }
 
 uint8_t
-LinkAdrReq::GetRepetitions()
+LinkAdrReq::GetNbTrans() const
 {
     NS_LOG_FUNCTION(this);
-
-    return (m_nbRep) ? m_nbRep : 1;
+    return m_nbTrans;
 }
 
 ////////////////

--- a/model/mac/mac-command.cc
+++ b/model/mac/mac-command.cc
@@ -186,7 +186,6 @@ uint8_t
 LinkCheckAns::GetGwCnt() const
 {
     NS_LOG_FUNCTION(this);
-
     return m_gwCnt;
 }
 
@@ -414,11 +413,11 @@ DutyCycleReq::Print(std::ostream& os) const
     os << ")";
 }
 
-double
+uint8_t
 DutyCycleReq::GetMaxDutyCycle() const
 {
     NS_LOG_FUNCTION(this);
-    return (m_maxDutyCycle) ? 1 / std::pow(2, double(m_maxDutyCycle)) : 1;
+    return m_maxDutyCycle;
 }
 
 //////////////////

--- a/model/mac/mac-command.cc
+++ b/model/mac/mac-command.cc
@@ -346,7 +346,14 @@ LinkAdrReq::GetEnabledChannelsList()
     return channelIndices;
 }
 
-int
+uint8_t
+LinkAdrReq::GetChMaskCntl()
+{
+    NS_LOG_FUNCTION(this);
+    return m_chMaskCntl;
+}
+
+uint8_t
 LinkAdrReq::GetRepetitions()
 {
     NS_LOG_FUNCTION(this);

--- a/model/mac/mac-command.h
+++ b/model/mac/mac-command.h
@@ -782,6 +782,23 @@ class DlChannelAns : public MacCommand
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
+    /**
+     * Get the UplinkFrequencyExists field of the DlChannelAns command.
+     *
+     * @return true The uplink frequency of the channel is valid for the end-device.
+     * @return false The uplink frequency is not defined for this channel. The downlink frequency
+     * can only be set for a channel that already has a valid uplink frequency
+     */
+    bool GetUplinkFrequencyExists() const;
+
+    /**
+     * Get the ChannelFrequencyOk field of the DlChannelAns command.
+     *
+     * @return true The end-device is able to use this frequency.
+     * @return false The end-device cannot use this frequency.
+     */
+    bool GetChannelFrequencyOk() const;
+
   private:
     bool m_uplinkFrequencyExists; //!< The Uplink Frequency Exists field
     bool m_channelFrequencyOk;    //!< The Channel Frequency Ok field

--- a/model/mac/mac-command.h
+++ b/model/mac/mac-command.h
@@ -15,7 +15,6 @@
 
 #include "ns3/buffer.h"
 #include "ns3/nstime.h"
-#include "ns3/object.h"
 
 namespace ns3
 {
@@ -49,6 +48,8 @@ enum MacCommandType
 };
 
 /**
+ * @ingroup lorawan
+ *
  * This base class is used to represent a general MAC command.
  *
  * Pure virtual methods that handle serialization, deserialization and other
@@ -58,66 +59,62 @@ enum MacCommandType
 class MacCommand : public SimpleRefCount<MacCommand>
 {
   public:
-    MacCommand();
-    virtual ~MacCommand();
+    MacCommand();          //!< Default constructor
+    virtual ~MacCommand(); //!< Destructor
 
     /**
      * Serialize the contents of this MAC command into a buffer, according to the
      * LoRaWAN standard.
      *
-     * \param start A pointer to the buffer into which to serialize the command.
+     * @param start A pointer to the buffer into which to serialize the command.
      */
     virtual void Serialize(Buffer::Iterator& start) const = 0;
 
     /**
      * Deserialize the buffer into a MAC command.
      *
-     * \param start A pointer to the buffer that contains the serialized command.
-     * \return the number of bytes that were consumed.
+     * @param start A pointer to the buffer that contains the serialized command.
+     * @return The number of bytes that were consumed.
      */
     virtual uint8_t Deserialize(Buffer::Iterator& start) = 0;
 
     /**
      * Print the contents of this MAC command in human-readable format.
      *
-     * \param os The std::ostream instance on which to print the MAC command.
+     * @param os The std::ostream instance on which to print the MAC command.
      */
     virtual void Print(std::ostream& os) const = 0;
 
     /**
      * Get serialized length of this MAC command.
      *
-     * \return The number of bytes the MAC command takes up.
+     * @return The number of bytes the MAC command takes up.
      */
     virtual uint8_t GetSerializedSize() const;
 
     /**
      * Get the commandType of this MAC command.
      *
-     * \return The type of MAC command this object represents.
+     * @return The type of MAC command this object represents.
      */
     virtual enum MacCommandType GetCommandType() const;
 
     /**
-     * Get the CID that corresponds to this MAC command.
+     * Get the CID that corresponds to a type of MAC command.
      *
-     * \return The CID as a uint8_t type.
+     * @param commandType The type of MAC command.
+     * @return The CID as a uint8_t type.
      */
     static uint8_t GetCIDFromMacCommand(enum MacCommandType commandType);
 
   protected:
-    /**
-     * The type of this command.
-     */
-    enum MacCommandType m_commandType;
-
-    /**
-     * This MAC command's serialized size.
-     */
-    uint8_t m_serializedSize;
+    enum MacCommandType m_commandType; //!< The type of this command.
+    uint8_t m_serializedSize;          //!< This MAC command's serialized size.
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the LinkCheckReq LoRaWAN MAC command.
  *
  * This command holds no variables, and just consists in the CID.
@@ -125,13 +122,16 @@ class MacCommand : public SimpleRefCount<MacCommand>
 class LinkCheckReq : public MacCommand
 {
   public:
-    LinkCheckReq();
+    LinkCheckReq(); //!< Default constructor
+
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the LinkCheckAns LoRaWAN MAC command.
  *
  * This command contains the demodulation margin and the number of receiving
@@ -140,7 +140,14 @@ class LinkCheckReq : public MacCommand
 class LinkCheckAns : public MacCommand
 {
   public:
-    LinkCheckAns();
+    LinkCheckAns(); //!< Default constructor
+
+    /**
+     * Constructor with given fields.
+     *
+     * @param margin The demodulation margin to set.
+     * @param gwCnt The gateway count to set.
+     */
     LinkCheckAns(uint8_t margin, uint8_t gwCnt);
 
     void Serialize(Buffer::Iterator& start) const override;
@@ -148,48 +155,22 @@ class LinkCheckAns : public MacCommand
     void Print(std::ostream& os) const override;
 
     /**
-     * Set the demodulation margin value.
-     *
-     * \param margin The demodulation margin to set.
-     */
-    void SetMargin(uint8_t margin);
-
-    /**
      * Get the demodulation margin value.
      *
-     * \return The demodulation margin value.
+     * @return The demodulation margin value.
      */
     uint8_t GetMargin() const;
 
     /**
-     * Set the gateway count value.
-     *
-     * \param gwCnt The count value to set.
-     */
-    void SetGwCnt(uint8_t gwCnt);
-
-    /**
      * Get the gateway count value.
      *
-     * \return The gateway count value.
+     * @return The gateway count value.
      */
     uint8_t GetGwCnt() const;
 
-    /**
-     * Increment this MacCommand's gwCnt value.
-     */
-    void IncrementGwCnt();
-
   private:
-    /**
-     * This MAC command's demodulation margin value.
-     */
-    uint8_t m_margin;
-
-    /**
-     * This MAC command's gateway count value.
-     */
-    uint8_t m_gwCnt;
+    uint8_t m_margin; //!< This MAC command's demodulation margin value.
+    uint8_t m_gwCnt;  //!< This MAC command's gateway count value.
 };
 
 /**
@@ -283,6 +264,8 @@ class LinkAdrReq : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the LinkAdrAns LoRaWAN MAC command.
  *
  * With this command, the end device acknowledges a LinkAdrReq.
@@ -290,21 +273,60 @@ class LinkAdrReq : public MacCommand
 class LinkAdrAns : public MacCommand
 {
   public:
-    LinkAdrAns();
+    LinkAdrAns(); //!< Default constructor
 
+    /**
+     * Constructor with given fields.
+     *
+     * @param powerAck The PowerACK field to set.
+     * @param dataRateAck The DataRateACK field to set.
+     * @param channelMaskAck The ChannelMaskACK field to set.
+     */
     LinkAdrAns(bool powerAck, bool dataRateAck, bool channelMaskAck);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
+    /**
+     * Get the PowerAck field value of the LinkAdrAns command.
+     *
+     * @return true The power level was successfully set.
+     * @return false The end-device is unable to operate at or below the requested power level. The
+     * command was discarded and the end-device state was not changed.
+     */
+    bool GetPowerAck() const;
+
+    /**
+     * Get the DataRateAck field value of the LinkAdrAns command.
+     *
+     * @return true The data rate was successfully set.
+     * @return false The data rate requested is unknown to the end-device or is not possible, given
+     * the channel mask provided (not supported by any of the enabled channels). The command was
+     * discarded, and the end-device state was not changed.
+     */
+    bool GetDataRateAck() const;
+
+    /**
+     * Get the ChannelMaskAck field value of the LinkAdrAns command.
+     *
+     * @return true The channel mask sent was successfully interpreted. All currently defined
+     * channel states were set according to the mask.
+     * @return false The channel mask enables a yet undefined channel or the channel mask required
+     * all channels to be disabled or the channel mask is incompatible with the resulting data rate
+     * or TX power. The command was discarded, and the end-device state was not changed.
+     */
+    bool GetChannelMaskAck() const;
+
   private:
-    bool m_powerAck;
-    bool m_dataRateAck;
-    bool m_channelMaskAck;
+    bool m_powerAck;       //!< The PowerACK field
+    bool m_dataRateAck;    //!< The DataRateACK field
+    bool m_channelMaskAck; //!< The ChannelMaskACK field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the DutyCycleReq LoRaWAN MAC command.
  *
  * With this command, the network server can limit the maximum aggregated
@@ -314,30 +336,33 @@ class LinkAdrAns : public MacCommand
 class DutyCycleReq : public MacCommand
 {
   public:
-    DutyCycleReq();
+    DutyCycleReq(); //!< Default constructor
+
     /**
      * Constructor providing initialization of all parameters.
      *
-     * \param dutyCycle The duty cycle as a 8-bit unsigned integer.
+     * @param maxDutyCycle The MaxDutyCycle field as a 8-bit unsigned integer.
      */
-    DutyCycleReq(uint8_t dutyCycle);
+    DutyCycleReq(uint8_t maxDutyCycle);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
     /**
-     * Get the maximum duty cycle prescribed by this Mac command, in fraction form.
+     * Get the maximum duty cycle prescribed by this Mac command.
      *
-     * \return The maximum duty cycle.
+     * @return The maximum aggregated duty cycle between 0 and 1.
      */
-    double GetMaximumAllowedDutyCycle() const;
+    double GetMaxDutyCycle() const;
 
   private:
-    uint8_t m_maxDCycle;
+    uint8_t m_maxDutyCycle; //!< The MaxDutyCycle field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the DutyCycleAns LoRaWAN MAC command.
  *
  * This command holds no variables, and just consists in the CID.
@@ -345,7 +370,7 @@ class DutyCycleReq : public MacCommand
 class DutyCycleAns : public MacCommand
 {
   public:
-    DutyCycleAns();
+    DutyCycleAns(); //!< Default constructor
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -353,21 +378,23 @@ class DutyCycleAns : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the RxParamSetupReq LoRaWAN MAC command.
  */
 class RxParamSetupReq : public MacCommand
 {
   public:
-    RxParamSetupReq();
+    RxParamSetupReq(); //!< Default constructor
 
     /**
      * Constructor providing initialization of all fields.
      *
-     * \param rx1DrOffset The Data Rate offset to use for the first receive window.
-     * \param rx2DataRate The Data Rate to use for the second receive window.
-     * \param frequency The frequency in Hz to use for the second receive window.
+     * @param rx1DrOffset The data rate offset to use for the first receive window.
+     * @param rx2DataRate The data rate to use for the second receive window.
+     * @param frequencyHz The frequency in Hz to use for the second receive window.
      */
-    RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency);
+    RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, uint32_t frequencyHz);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -376,43 +403,46 @@ class RxParamSetupReq : public MacCommand
     /**
      * Get this command's Rx1DrOffset parameter.
      *
-     * \return The Rx1DrOffset parameter.
+     * @return The Rx1DrOffset parameter.
      */
     uint8_t GetRx1DrOffset();
 
     /**
      * Get this command's Rx2DataRate parameter.
      *
-     * \return The Rx2DataRate parameter.
+     * @return The Rx2DataRate parameter.
      */
     uint8_t GetRx2DataRate();
 
     /**
      * Get this command's frequency.
      *
-     * \return The frequency parameter, in Hz.
+     * @return The frequency parameter, in Hz.
      */
-    double GetFrequency();
+    uint32_t GetFrequency();
 
   private:
-    uint8_t m_rx1DrOffset;
-    uint8_t m_rx2DataRate;
-    double m_frequency; //!< The frequency _in Hz_
+    uint8_t m_rx1DrOffset;  //!< The RX1DROffset field
+    uint8_t m_rx2DataRate;  //!< The RX2DataRate field
+    uint32_t m_frequencyHz; //!< The Frequency field, _in Hz_
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the RxParamSetupAns LoRaWAN MAC command.
  */
 class RxParamSetupAns : public MacCommand
 {
   public:
-    RxParamSetupAns();
+    RxParamSetupAns(); //!< Default constructor
+
     /**
      * Constructor with initialization of all parameters.
      *
-     * \param rx1DrOffsetAck Whether or not the offset was correctly set.
-     * \param rx2DataRateAck Whether or not the second slot data rate was correctly set.
-     * \param channelAck Whether or not the second slot frequency was correctly set.
+     * @param rx1DrOffsetAck Whether or not the offset was correctly set.
+     * @param rx2DataRateAck Whether or not the second slot data rate was correctly set.
+     * @param channelAck Whether or not the second slot frequency was correctly set.
      */
     RxParamSetupAns(bool rx1DrOffsetAck, bool rx2DataRateAck, bool channelAck);
 
@@ -420,19 +450,48 @@ class RxParamSetupAns : public MacCommand
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
+    /**
+     * Get the Rx1DrOffsetAck field value of the RxParamSetupAns command.
+     *
+     * @return true RX1 data-rate offset was successfully set.
+     * @return false The uplink/downlink data rate offset for RX1 slot is not within the allowed
+     * range.
+     */
+    bool GetRx1DrOffsetAck() const;
+
+    /**
+     * Get the Rx2DataRateAck field value of the RxParamSetupAns command.
+     *
+     * @return true RX2 slot data rate was successfully set.
+     * @return false The data rate requested is unknown to the end-device.
+     */
+    bool GetRx2DataRateAck() const;
+
+    /**
+     * Get the ChannelAck field value of the RxParamSetupAns command.
+     *
+     * @return true RX2 slot channel was successfully set.
+     * @return false The frequency requested is not usable by the end-device.
+     */
+    bool GetChannelAck() const;
+
   private:
-    bool m_rx1DrOffsetAck;
-    bool m_rx2DataRateAck;
-    bool m_channelAck;
+    bool m_rx1DrOffsetAck; //!< The RX1DROffsetACK field
+    bool m_rx2DataRateAck; //!< The RX2DataRateACK field
+    bool m_channelAck;     //!< The ChannelACK field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the DevStatusReq LoRaWAN MAC command.
+ *
+ * This command holds no variables, and just consists in the CID.
  */
 class DevStatusReq : public MacCommand
 {
   public:
-    DevStatusReq();
+    DevStatusReq(); //!< Default constructor
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -440,17 +499,20 @@ class DevStatusReq : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the DevStatusAns LoRaWAN MAC command.
  */
 class DevStatusAns : public MacCommand
 {
   public:
-    DevStatusAns();
+    DevStatusAns(); //!< Default constructor
+
     /**
      * Constructor with initialization of all parameters.
      *
-     * \param battery The battery level in [0, 255].
-     * \param margin The demodulation margin of the last received DevStatusReq packet.
+     * @param battery The battery level in [0, 255].
+     * @param margin The demodulation margin of the last received DevStatusReq packet.
      */
     DevStatusAns(uint8_t battery, uint8_t margin);
 
@@ -461,70 +523,94 @@ class DevStatusAns : public MacCommand
     /**
      * Get the battery information contained in this MAC command.
      *
-     * \return The battery level.
+     * @return The battery level.
      */
     uint8_t GetBattery() const;
 
     /**
      * Get the demodulation margin contained in this MAC command.
      *
-     * \return The margin.
+     * @return The margin.
      */
     uint8_t GetMargin() const;
 
   private:
-    uint8_t m_battery;
-    uint8_t m_margin;
+    uint8_t m_battery; //!< The Battery field
+    uint8_t m_margin;  //!< The RadioStatus field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the NewChannelReq LoRaWAN MAC command.
  */
 class NewChannelReq : public MacCommand
 {
   public:
-    NewChannelReq();
+    NewChannelReq(); //!< Default constructor
 
     /**
      * Constructor providing initialization of all parameters.
      *
-     * \param chIndex The index of the channel this command wants to operate on.
-     * \param frequency The new frequency for this channel, in Hz.
-     * \param minDataRate The minimum data rate allowed on this channel.
-     * \param maxDataRate The minimum data rate allowed on this channel.
+     * @param chIndex The index of the channel this command wants to operate on.
+     * @param frequencyHz The new frequency for this channel in Hz.
+     * @param minDataRate The minimum data rate allowed on this channel.
+     * @param maxDataRate The maximum data rate allowed on this channel.
      */
-    NewChannelReq(uint8_t chIndex, double frequency, uint8_t minDataRate, uint8_t maxDataRate);
+    NewChannelReq(uint8_t chIndex, uint32_t frequencyHz, uint8_t minDataRate, uint8_t maxDataRate);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
+    /**
+     * Get the the ChIndex field contained in this MAC command.
+     *
+     * @return The ChIndex field.
+     */
     uint8_t GetChannelIndex() const;
-    double GetFrequency() const;
+    /**
+     * Get the the Frequency field contained in this MAC command.
+     *
+     * @return The Frequency field in Hz.
+     */
+    uint32_t GetFrequency() const;
+    /**
+     * Get the the MinDR field contained in this MAC command.
+     *
+     * @return The MinDR field.
+     */
     uint8_t GetMinDataRate() const;
+    /**
+     * Get the the MaxDR field contained in this MAC command.
+     *
+     * @return The MaxDR field.
+     */
     uint8_t GetMaxDataRate() const;
 
   private:
-    uint8_t m_chIndex;
-    double m_frequency;
-    uint8_t m_minDataRate;
-    uint8_t m_maxDataRate;
+    uint8_t m_chIndex;      //!< The ChIndex field
+    uint32_t m_frequencyHz; //!< The Frequency field, in Hz
+    uint8_t m_minDataRate;  //!< The MinDR field
+    uint8_t m_maxDataRate;  //!< The MaxDR field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the NewChannelAns LoRaWAN MAC command.
  */
 class NewChannelAns : public MacCommand
 {
   public:
-    NewChannelAns();
+    NewChannelAns(); //!< Default constructor
 
     /**
      * Constructor providing initialization of all parameters.
      *
-     * \param dataRateRangeOk Whether or not the requested data rate range was set
+     * @param dataRateRangeOk Whether or not the requested data rate range was set
      * correctly.
-     * \param channelFrequencyOk Whether or not the requested channel frequency
+     * @param channelFrequencyOk Whether or not the requested channel frequency
      * was set correctly.
      */
     NewChannelAns(bool dataRateRangeOk, bool channelFrequencyOk);
@@ -533,23 +619,42 @@ class NewChannelAns : public MacCommand
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
+    /**
+     * Get the DataRateRangOk field of the NewChannelAns command.
+     *
+     * @return true The data-rate range is compatible with the capabilities of the end-device.
+     * @return false The designated data-rate range exceeds the ones currently defined for this
+     * end-device.
+     */
+    bool GetDataRateRangeOk() const;
+
+    /**
+     * Get the ChannelFrequencyOk field of the NewChannelAns command.
+     *
+     * @return true The end-device is able to use this frequency.
+     * @return false The end-device cannot use this frequency.
+     */
+    bool GetChannelFrequencyOk() const;
+
   private:
-    bool m_dataRateRangeOk;
-    bool m_channelFrequencyOk;
+    bool m_dataRateRangeOk;    //!< The Data-rate range ok field
+    bool m_channelFrequencyOk; //!< The Channel frequency ok field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the RxTimingSetupReq LoRaWAN MAC command.
  */
 class RxTimingSetupReq : public MacCommand
 {
   public:
-    RxTimingSetupReq();
+    RxTimingSetupReq(); //!< Default constructor
 
     /**
      * Constructor providing initialization of all parameters.
      *
-     * \param delay The delay encoded in this MAC command.
+     * @param delay The delay encoded in this MAC command.
      */
     RxTimingSetupReq(uint8_t delay);
 
@@ -560,23 +665,25 @@ class RxTimingSetupReq : public MacCommand
     /**
      * Get the first window delay as a Time instance.
      *
-     * \return The delay.
+     * @return The delay.
      */
-    Time GetDelay();
+    Time GetDelay() const;
 
   private:
-    uint8_t m_delay;
+    uint8_t m_delay; //!< The Del field
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the RxTimingSetupAns LoRaWAN MAC command.
  *
- * This MAC command has an empty payload.
+ * This command holds no variables, and just consists in the CID.
  */
 class RxTimingSetupAns : public MacCommand
 {
   public:
-    RxTimingSetupAns();
+    RxTimingSetupAns(); //!< Default constructor
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -586,12 +693,16 @@ class RxTimingSetupAns : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the TxParamSetupReq LoRaWAN MAC command.
+ *
+ * @todo implementation
  */
 class TxParamSetupReq : public MacCommand
 {
   public:
-    TxParamSetupReq();
+    TxParamSetupReq(); //!< Default constructor
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -601,12 +712,16 @@ class TxParamSetupReq : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the TxParamSetupAns LoRaWAN MAC command.
+ *
+ * This command holds no variables, and just consists in the CID.
  */
 class TxParamSetupAns : public MacCommand
 {
   public:
-    TxParamSetupAns();
+    TxParamSetupAns(); //!< Default constructor
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -616,46 +731,50 @@ class TxParamSetupAns : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the DlChannelReq LoRaWAN MAC command.
  */
 class DlChannelReq : public MacCommand
 {
   public:
-    DlChannelReq();
+    DlChannelReq(); //!< Default constructor
 
     /**
      * Constructor providing initialization of all parameters.
      *
-     * \param chIndex The index of the channel this command wants to operate on.
-     * \param frequency The new downlink frequency for this channel, in Hz.
+     * @param chIndex The index of the channel this command wants to operate on.
+     * @param frequency The new downlink frequency for this channel, in Hz.
      */
-    DlChannelReq(uint8_t chIndex, double frequency);
+    DlChannelReq(uint8_t chIndex, uint32_t frequencyHz);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
     uint8_t GetChannelIndex() const;
-    double GetFrequency() const;
+    uint32_t GetFrequency() const;
 
   private:
-    uint8_t m_chIndex;
-    double m_frequency;
+    uint8_t m_chIndex;      //!< The ChIndex field
+    uint32_t m_frequencyHz; //!< The Frequency field, in Hz
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the DlChannelAns LoRaWAN MAC command.
  */
 class DlChannelAns : public MacCommand
 {
   public:
-    DlChannelAns();
+    DlChannelAns(); //!< Default constructor
 
     /**
      * Constructor providing initialization of all parameters.
      *
-     * \param uplinkFrequencyExists Whether the uplink frequency exists for the channel.
-     * \param channelFrequencyOk Whether the downlink frequency can be used by this device.
+     * @param uplinkFrequencyExists Whether the uplink frequency exists for the channel.
+     * @param channelFrequencyOk Whether the downlink frequency can be used by this device.
      */
     DlChannelAns(bool uplinkFrequencyExists, bool channelFrequencyOk);
 
@@ -664,11 +783,11 @@ class DlChannelAns : public MacCommand
     void Print(std::ostream& os) const override;
 
   private:
-    bool m_uplinkFrequencyExists;
-    bool m_channelFrequencyOk;
+    bool m_uplinkFrequencyExists; //!< The Uplink Frequency Exists field
+    bool m_channelFrequencyOk;    //!< The Channel Frequency Ok field
 };
 
 } // namespace lorawan
-
 } // namespace ns3
-#endif /* DEVICE_STATUS_H */
+
+#endif /* MAC_COMMAND_H */

--- a/model/mac/mac-command.h
+++ b/model/mac/mac-command.h
@@ -654,23 +654,23 @@ class RxTimingSetupReq : public MacCommand
     /**
      * Constructor providing initialization of all parameters.
      *
-     * @param delay The delay encoded in this MAC command.
+     * @param del The delay encoded in this MAC command.
      */
-    RxTimingSetupReq(uint8_t delay);
+    RxTimingSetupReq(uint8_t del);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
     void Print(std::ostream& os) const override;
 
     /**
-     * Get the first window delay as a Time instance.
+     * Get the first window delay field.
      *
-     * @return The delay.
+     * @return The Del field value.
      */
-    Time GetDelay() const;
+    uint8_t GetDel() const;
 
   private:
-    uint8_t m_delay; //!< The Del field
+    uint8_t m_del; //!< The Del field
 };
 
 /**

--- a/model/mac/mac-command.h
+++ b/model/mac/mac-command.h
@@ -241,11 +241,19 @@ class LinkAdrReq : public MacCommand
     std::list<int> GetEnabledChannelsList();
 
     /**
+     * Get the ChMaskCntl field, used as an indicator of the 16-channel bank to apply the ChMask to.
+     * The interpretation of this field is region-dependent.
+     *
+     * \return The ChMaskCntl field.
+     */
+    uint8_t GetChMaskCntl();
+
+    /**
      * Get the number of repetitions prescribed by this MAC command.
      *
      * \return The number of repetitions.
      */
-    int GetRepetitions();
+    uint8_t GetRepetitions();
 
   private:
     uint8_t m_dataRate;

--- a/model/mac/mac-command.h
+++ b/model/mac/mac-command.h
@@ -193,6 +193,8 @@ class LinkCheckAns : public MacCommand
 };
 
 /**
+ * @ingroup lorawan
+ *
  * Implementation of the LinkAdrReq LoRaWAN MAC command.
  *
  * With this command, the network server can request a device to change its
@@ -202,13 +204,28 @@ class LinkCheckAns : public MacCommand
 class LinkAdrReq : public MacCommand
 {
   public:
-    LinkAdrReq();
+    LinkAdrReq(); //!< Default constructor
 
+    /**
+     * Constructor with given fields.
+     *
+     * The parameters of this constructor are serializable fields of the MAC command specified by
+     * the LoRaWAN protocol. They represent MAC and PHY layer configurations to be applied by the
+     * receiving end device. See, [LoRaWAN® L2 1.0.4 Specification (TS001-1.0.4)] and [LoRaWAN®
+     * Regional Parameters RP002-1.0.4] for more details on how the fields are used and which
+     * physical values they stand for.
+     *
+     * @param dataRate The DataRate field to set.
+     * @param txPower The TXPower field to set.
+     * @param chMask The ChMask field to set.
+     * @param chMaskCntl The ChMaskCntl field to set.
+     * @param nbTrans The NbTrans field to set.
+     */
     LinkAdrReq(uint8_t dataRate,
                uint8_t txPower,
-               uint16_t channelMask,
+               uint16_t chMask,
                uint8_t chMaskCntl,
-               uint8_t nbRep);
+               uint8_t nbTrans);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -217,9 +234,9 @@ class LinkAdrReq : public MacCommand
     /**
      * Return the data rate prescribed by this MAC command.
      *
-     * \return An unsigned 8-bit integer containing the data rate.
+     * @return An unsigned 8-bit integer containing the data rate.
      */
-    uint8_t GetDataRate();
+    uint8_t GetDataRate() const;
 
     /**
      * Get the transmission power prescribed by this MAC command.
@@ -228,39 +245,41 @@ class LinkAdrReq : public MacCommand
      * dBm when communicating it to the PHY, and the translation will vary based
      * on the region of the device.
      *
-     * \return The TX power, encoded as an unsigned 8-bit integer.
+     * @return The TX power, encoded as an unsigned 8-bit integer.
      */
-    uint8_t GetTxPower();
+    uint8_t GetTxPower() const;
 
     /**
-     * Get the list of enabled channels. This method takes the 16-bit channel mask
-     * and translates it to a list of integers that can be more easily parsed.
+     * Get the 16 bit mask of enabled channels.
      *
-     * \return The list of enabled channels.
+     * @return The 16 bit channel mask.
      */
-    std::list<int> GetEnabledChannelsList();
+    uint16_t GetChMask() const;
 
     /**
      * Get the ChMaskCntl field, used as an indicator of the 16-channel bank to apply the ChMask to.
+     *
      * The interpretation of this field is region-dependent.
      *
-     * \return The ChMaskCntl field.
+     * @return The ChMaskCntl field.
      */
-    uint8_t GetChMaskCntl();
+    uint8_t GetChMaskCntl() const;
 
     /**
-     * Get the number of repetitions prescribed by this MAC command.
+     * Get the number of repeated transmissions prescribed by this MAC command.
      *
-     * \return The number of repetitions.
+     * @return The number of repeated transmissions.
      */
-    uint8_t GetRepetitions();
+    uint8_t GetNbTrans() const;
 
   private:
-    uint8_t m_dataRate;
-    uint8_t m_txPower;
-    uint16_t m_channelMask;
-    uint8_t m_chMaskCntl;
-    uint8_t m_nbRep;
+    uint8_t m_dataRate;   //!< The DataRate field, a serializable parameter for setting the
+                          //!< spreading factor and bandwidth of end devices
+    uint8_t m_txPower;    //!< The TXPower field, a serializable parameter for setting the
+                          //!< transmission power of end devices
+    uint16_t m_chMask;    //!< The ChMask field
+    uint8_t m_chMaskCntl; //!< The ChMaskCntl field
+    uint8_t m_nbTrans;    //!< The NbTrans field
 };
 
 /**

--- a/model/mac/mac-command.h
+++ b/model/mac/mac-command.h
@@ -352,9 +352,9 @@ class DutyCycleReq : public MacCommand
     /**
      * Get the maximum duty cycle prescribed by this Mac command.
      *
-     * @return The maximum aggregated duty cycle between 0 and 1.
+     * @return The maximum aggregated duty cycle field value.
      */
-    double GetMaxDutyCycle() const;
+    uint8_t GetMaxDutyCycle() const;
 
   private:
     uint8_t m_maxDutyCycle; //!< The MaxDutyCycle field

--- a/model/mac/recv-window-manager.cc
+++ b/model/mac/recv-window-manager.cc
@@ -108,6 +108,30 @@ RecvWindowManager::SetFrequency(WinId id, double f)
     m_win[id].frequency = f;
 }
 
+Time
+RecvWindowManager::GetRx1Delay()
+{
+    return m_win[FIRST].delay;
+}
+
+uint8_t
+RecvWindowManager::GetSf(WinId id)
+{
+    return m_win[id].sf;
+}
+
+Time
+RecvWindowManager::GetDuration(WinId id)
+{
+    return m_win[id].duration;
+}
+
+double
+RecvWindowManager::GetFrequency(WinId id)
+{
+    return m_win[id].frequency;
+}
+
 void
 RecvWindowManager::SetPhy(Ptr<EndDeviceLoraPhy> phy)
 {
@@ -156,8 +180,7 @@ RecvWindowManager::CloseWin(WinId id)
     switch (m_phy->GetState())
     {
     case EndDeviceLoraPhy::TX:
-        NS_ABORT_MSG("PHY was in TX mode when attempting to "
-                     << "close a receive window.");
+        NS_ABORT_MSG("PHY was in TX mode when attempting to close a receive window.");
     case EndDeviceLoraPhy::SLEEP:
         NS_ABORT_MSG("PHY was in already in SLEEP mode when attempting to "
                      << "close a receive window.");

--- a/model/mac/recv-window-manager.cc
+++ b/model/mac/recv-window-manager.cc
@@ -158,15 +158,26 @@ void
 RecvWindowManager::OpenWin(WinId id)
 {
     NS_LOG_FUNCTION(this << id);
-    // Set reception window parameters
-    m_phy->SetRxSpreadingFactor(m_win[id].sf);
-    m_phy->SetRxFrequency(m_win[id].frequency);
-    NS_LOG_DEBUG("Opening reception window with parameters: freq="
-                 << m_win[id].frequency << "Hz, SF=" << unsigned(m_win[id].sf) << ".");
-    // Set Phy in Standby mode
-    m_phy->SwitchToStandby();
-    // Schedule closure
-    m_closing = Simulator::Schedule(m_win[id].duration, &RecvWindowManager::CloseWin, this, id);
+    switch (m_phy->GetState())
+    {
+    case EndDeviceLoraPhy::TX:
+        NS_ABORT_MSG("PHY was in TX mode when attempting to open a receive window.");
+    case EndDeviceLoraPhy::RX:
+        // PHY is receiving: let it finish
+        NS_LOG_DEBUG("PHY is receiving: Receive will handle the result.");
+        return;
+    case EndDeviceLoraPhy::SLEEP:
+    case EndDeviceLoraPhy::STANDBY:
+        // Set reception window parameters
+        m_phy->SetRxSpreadingFactor(m_win[id].sf);
+        m_phy->SetRxFrequency(m_win[id].frequency);
+        NS_LOG_DEBUG("Opening reception window with parameters: freq="
+                     << m_win[id].frequency << "Hz, SF=" << unsigned(m_win[id].sf) << ".");
+        // Set Phy in Standby mode
+        m_phy->SwitchToStandby();
+        // Schedule closure
+        m_closing = Simulator::Schedule(m_win[id].duration, &RecvWindowManager::CloseWin, this, id);
+    }
 }
 
 void

--- a/model/mac/recv-window-manager.h
+++ b/model/mac/recv-window-manager.h
@@ -67,7 +67,16 @@ class RecvWindowManager : public Object
     /* Set frequency of window based on id */
     void SetFrequency(WinId id, double f);
 
-    /* Set device physiscal layer */
+    /* Get RX1 delay (RX2 delay will be set to + 1s) */
+    Time GetRx1Delay();
+    /* Get SF of window based on id */
+    uint8_t GetSf(WinId id);
+    /* Get duration of window based on id */
+    Time GetDuration(WinId id);
+    /* Get frequency of window based on id */
+    double GetFrequency(WinId id);
+
+    /* Set device physical layer */
     void SetPhy(Ptr<EndDeviceLoraPhy> phy);
     /* Set callback function to be called on expiration of second reception window */
     void SetNoRecvCallback(NoRecvCallback cb);

--- a/test/examples-to-run.py
+++ b/test/examples-to-run.py
@@ -9,7 +9,7 @@
 cpp_examples = [
     ("simple-network-example", "True", "True"),
     ("network-server-example", "True", "True"),
-    ("complete-network-example", "True", "True"),
+    ("complete-network-example --realisticChannel", "True", "True"),
     ("adr-example", "True", "True"),
     ("lorawan-energy-model-example", "True", "True"),
     ("aloha-throughput", "True", "True"),

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2418,9 +2418,13 @@ class AdrBackoffTest : public TestCase
      * Create and schedule an empty payload downlink destined for the LoRaWAN MAC. This is used
      * to test resetting the ADR backoff procedure.
      *
+     * Timing should be chosen to completely overwrite the RX window process, for example just after
+     * the transmission ends. It is not realistic but we do not care: RX windows should have their
+     * own test suite.
+     *
      * @note This does not call Simulator::Run(), enabling preemptive scheduling
      *
-     * @param after Delay to schedule the packet after to sync with rx windows
+     * @param after Delay to schedule the packet after
      */
     void ScheduleDownlink(Time after);
 
@@ -2549,7 +2553,7 @@ AdrBackoffTest::DoRun()
     }
 
     Reset();
-    // ADRACKReq back to false after downlink
+    // ADRACKReq back to false after downlink in RX1
     {
         LoraFrameHeader fhdr;
         // Trigger ADRACKReq
@@ -2558,7 +2562,7 @@ AdrBackoffTest::DoRun()
             if (fCnt == ADR_ACK_LIMIT)
             {
                 // After ADR_ACK_LIMIT uplinks, schedule a downlink in the rx window
-                ScheduleDownlink(Minutes(20) + Seconds(1.2));
+                ScheduleDownlink(Minutes(20) + Seconds(2));
             }
             SendUplink(Minutes(20), fhdr);
             NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), fCnt, "Unexpected FCnt value in uplink FHDR");
@@ -2605,9 +2609,13 @@ class RetransmissionTest : public TestCase
      * Create and schedule an empty payload downlink destined for the LoRaWAN MAC. This is used
      * to test stopping the retransmission procedure.
      *
+     * Timing should be chosen to completely overwrite the RX window process, for example just after
+     * the transmission ends. It is not realistic but we do not care: RX windows should have their
+     * own test suite.
+     *
      * @note This does not call Simulator::Run(), enabling preemptive scheduling
      *
-     * @param after Delay to schedule the packet after to sync with rx windows
+     * @param after Delay to schedule the packet after
      * @param ack Whether to set the ACK flag in the frame header
      */
     void ScheduleDownlink(Time after, bool ack = false);
@@ -2881,7 +2889,7 @@ RetransmissionTest::DoRun()
         uint8_t nbTrans = 3;
         m_mac->SetNumberOfTransmissions(nbTrans);
         m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
-        ScheduleDownlink(Seconds(1.2));
+        ScheduleDownlink(Seconds(1));
         LoraFrameHeader fhdr;
         SendUplink(fhdr);
         NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
@@ -2903,7 +2911,7 @@ RetransmissionTest::DoRun()
         uint8_t nbTrans = 13;
         m_mac->SetNumberOfTransmissions(nbTrans);
         m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
-        ScheduleDownlink(Seconds(30.3));
+        ScheduleDownlink(Seconds(30));
         LoraFrameHeader fhdr;
         SendUplink(fhdr);
         NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
@@ -3014,7 +3022,7 @@ RetransmissionTest::DoRun()
         uint8_t nbTrans = 10;
         m_mac->SetNumberOfTransmissions(nbTrans);
         m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
-        ScheduleDownlink(Seconds(45));
+        ScheduleDownlink(Seconds(44));
         LoraFrameHeader fhdr;
         SendUplink(fhdr);
         NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
@@ -3042,7 +3050,7 @@ RetransmissionTest::DoRun()
         uint8_t nbTrans = 14;
         m_mac->SetNumberOfTransmissions(nbTrans);
         m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
-        ScheduleDownlink(Seconds(67), true);
+        ScheduleDownlink(Seconds(66), true);
         LoraFrameHeader fhdr;
         SendUplink(fhdr);
         NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
@@ -3084,6 +3092,7 @@ LorawanTestSuite::LorawanTestSuite()
     // LogComponentEnable("LorawanMac", LOG_LEVEL_DEBUG);
     // LogComponentEnable("BaseEndDeviceLorawanMac", LOG_LEVEL_DEBUG);
     // LogComponentEnable("ClassAEndDeviceLorawanMac", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("RecvWindowManager", LOG_LEVEL_DEBUG);
     // LogComponentEnable("EndDeviceLoraPhy", LOG_LEVEL_DEBUG);
     // LogComponentEnable("LoraPhy", LOG_LEVEL_DEBUG);
     // LogComponentEnable("LoraChannel", LOG_LEVEL_DEBUG);

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2330,6 +2330,63 @@ MacCommandTest::DoRun()
         auto rtsa = DynamicCast<RxTimingSetupAns>(*(answers.begin()));
         NS_TEST_ASSERT_MSG_NE(rtsa, nullptr, "NewChannelAns was expected, cmd type cast failed");
     }
+
+    Reset();
+    // DlChannelReq: valid RX1 reply frequency is correctly set
+    {
+        uint8_t chIndex = 0;
+        uint32_t frequencyHz = 865100000;
+        auto answers = RunMacCommand<DlChannelReq>(chIndex, frequencyHz);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto c = m_mac->GetLogicalChannelManager()->GetChannel(chIndex);
+        NS_TEST_ASSERT_MSG_NE(c, nullptr, "Channel at chIndex slot expected not to be nullptr");
+        NS_TEST_ASSERT_MSG_EQ(c->GetReplyFrequency(),
+                              frequencyHz,
+                              "Channel reply frequency expected equal to DlChannelReq frequency");
+        auto dca = DynamicCast<DlChannelAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(dca, nullptr, "DlChannelAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(dca->GetUplinkFrequencyExists(),
+                              true,
+                              "UplinkFrequencyExists != true");
+        NS_TEST_EXPECT_MSG_EQ(dca->GetChannelFrequencyOk(), true, "ChannelFrequencyOk != true");
+    }
+
+    Reset();
+    // DlChannelReq: valid RX1 reply frequency is not set for invalid channel index
+    {
+        uint8_t chIndex = 4;
+        uint32_t frequencyHz = 868100000;
+        auto answers = RunMacCommand<DlChannelReq>(chIndex, frequencyHz);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto c = m_mac->GetLogicalChannelManager()->GetChannel(chIndex);
+        NS_TEST_ASSERT_MSG_EQ(c, nullptr, "Channel at chIndex slot expected to be nullptr");
+        auto dca = DynamicCast<DlChannelAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(dca, nullptr, "DlChannelAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(dca->GetUplinkFrequencyExists(),
+                              false,
+                              "UplinkFrequencyExists != false");
+        NS_TEST_EXPECT_MSG_EQ(dca->GetChannelFrequencyOk(), true, "ChannelFrequencyOk != true");
+    }
+
+    Reset();
+    // DlChannelReq: invalid RX1 reply frequency is not set
+    { // WARNING: default values are manually set here
+        uint8_t chIndex = 2;
+        uint32_t frequencyHz = 862000000;
+        auto answers = RunMacCommand<DlChannelReq>(chIndex, frequencyHz);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto c = m_mac->GetLogicalChannelManager()->GetChannel(chIndex);
+        NS_TEST_ASSERT_MSG_NE(c, nullptr, "Channel at chIndex slot expected not to be nullptr");
+        NS_TEST_ASSERT_MSG_EQ(c->GetReplyFrequency(),
+                              868500000,
+                              "Channel reply frequency expected to be default");
+        auto dca = DynamicCast<DlChannelAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(dca, nullptr, "DlChannelAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(dca->GetUplinkFrequencyExists(),
+                              true,
+                              "UplinkFrequencyExists != true");
+        NS_TEST_EXPECT_MSG_EQ(dca->GetChannelFrequencyOk(), false, "ChannelFrequencyOk != false");
+    }
 }
 
 /**

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1,32 +1,35 @@
-
-// Include headers of classes to test
-#include "ns3/constant-position-mobility-model.h"
-#include "ns3/end-device-lora-phy.h"
-#include "ns3/gateway-lora-phy.h"
-#include "ns3/log.h"
-#include "ns3/lora-frame-header.h"
-#include "ns3/lorawan-helper.h"
-#include "ns3/lorawan-mac-header.h"
-#include "ns3/mobility-helper.h"
-#include "ns3/one-shot-sender-helper.h"
+/*
+ * Copyright (c) 2017 University of Padova
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
 
 // An essential include is test.h
+#include "ns3/constant-position-mobility-model.h"
+#include "ns3/simulator.h"
 #include "ns3/test.h"
+
+// Include headers of classes to test
+#include "ns3/elora-module.h"
 
 using namespace ns3;
 using namespace lorawan;
 
 NS_LOG_COMPONENT_DEFINE("LorawanTestSuite");
 
-/********************
- * InterferenceTest *
- ********************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests interference computations in a number of possible scenarios using the
+ * LoraInterferenceHelper class
+ */
 class InterferenceTest : public TestCase
 {
   public:
-    InterferenceTest();
-    ~InterferenceTest() override;
+    InterferenceTest();           //!< Default constructor
+    ~InterferenceTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -51,146 +54,148 @@ InterferenceTest::DoRun()
     NS_LOG_DEBUG("InterferenceTest");
 
     // The following tests are designed around GOURSAUD signal-to-interference matrix
-    auto interference = CreateObject<LoraInterferenceHelper>();
-    interference->SetIsolationMatrix(LoraInterferenceHelper::GOURSAUD);
+    LoraInterferenceHelper interferenceHelper;
+    interferenceHelper.SetIsolationMatrix(LoraInterferenceHelper::GOURSAUD);
 
-    double frequency = 868100000;
-    double differentFrequency = 868300000;
+    uint32_t frequencyHz = 868100000;
+    uint32_t differentFrequencyHz = 868300000;
 
     Ptr<LoraInterferenceHelper::Event> event;
     Ptr<LoraInterferenceHelper::Event> event1;
 
     // Test overlap duration
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interference->Add(Seconds(1), 14, 12, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->GetOverlapTime(event, event1),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    event1 = interferenceHelper.Add(Seconds(1), 14, 12, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(1),
                           "Overlap computation didn't give the expected result");
+    interferenceHelper.ClearAllEvents();
 
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interference->Add(Seconds(1.5), 14, 12, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->GetOverlapTime(event, event1),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    event1 = interferenceHelper.Add(Seconds(1.5), 14, 12, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(1.5),
                           "Overlap computation didn't give the expected result");
+    interferenceHelper.ClearAllEvents();
 
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interference->Add(Seconds(3), 14, 12, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->GetOverlapTime(event, event1),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    event1 = interferenceHelper.Add(Seconds(3), 14, 12, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(2),
                           "Overlap computation didn't give the expected result");
+    interferenceHelper.ClearAllEvents();
 
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interference->Add(Seconds(2), 14, 12, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    event1 = interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequencyHz);
     // Because of some strange behavior, this test would get stuck if we used the same syntax of the
     // previous ones. This works instead.
-    bool retval = interference->GetOverlapTime(event, event1) == Seconds(2);
+    bool retval = interferenceHelper.GetOverlapTime(event, event1) == Seconds(2);
     NS_TEST_EXPECT_MSG_EQ(retval, true, "Overlap computation didn't give the expected result");
+    interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet survives
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14, 12, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
+    interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet survives
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 - 7, 7, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 - 7, 7, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
+    interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet destroyed
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 - 6, 7, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 - 6, 7, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           7,
                           "Packet was not destroyed by interference as expected");
+    interferenceHelper.ClearAllEvents();
 
     // Partial overlap, packet survives
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(1), 14 - 6, 7, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(1), 14 - 6, 7, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
+    interferenceHelper.ClearAllEvents();
 
     // Different frequencys
     // Packet would be destroyed if they were on the same frequency, but survives
     // since they are on different frequencies
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14, 7, nullptr, differentFrequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14, 7, nullptr, differentFrequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
+    interferenceHelper.ClearAllEvents();
 
     // Different SFs
-    // Packet would be destroyed if they both were SF7, but survives thanks to SF
-    // orthogonality
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    // Packet would be destroyed if they both were SF7, but survives thanks to spreading factor
+    // semi-orthogonality
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
+    interferenceHelper.ClearAllEvents();
 
-    // SF imperfect orthogonality
+    // Spreading factor imperfect orthogonality
     // Different SFs are orthogonal only up to a point
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 17, 8, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 17, 8, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           8,
                           "Packet was not destroyed by interference as expected");
+    interferenceHelper.ClearAllEvents();
 
-    // If a more 'distant' SF is used, isolation gets better
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 17, 10, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    // If a more 'distant' spreading factor is used, isolation gets better
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 17, 10, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet was destroyed by interference while it should have survived");
+    interferenceHelper.ClearAllEvents();
 
     // Cumulative interference
-    // Same-SF interference is cumulative
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    // Same spreading factor interference is cumulative
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           8,
                           "Packet was not destroyed by interference as expected");
+    interferenceHelper.ClearAllEvents();
 
     // Cumulative interference
     // Interference is not cumulative between different SFs
-    interference->ClearAllEvents();
-    event = interference->Add(Seconds(2), 14, 7, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 9, nullptr, frequency);
-    interference->Add(Seconds(2), 14 + 16, 10, nullptr, frequency);
-    NS_TEST_EXPECT_MSG_EQ(interference->IsDestroyedByInterference(event),
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 9, nullptr, frequencyHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 10, nullptr, frequencyHz);
+    NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
+    interferenceHelper.ClearAllEvents();
 }
 
-/***************
- * AddressTest *
- ***************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests LoraDeviceAddress comparison operators overrides and generation of new addresses with
+ * LoraDeviceAddressGenerator
+ */
 class AddressTest : public TestCase
 {
   public:
-    AddressTest();
-    ~AddressTest() override;
+    AddressTest();           //!< Default constructor
+    ~AddressTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -264,15 +269,17 @@ AddressTest::DoRun()
                           "LoraDeviceAddressGenerator doesn't increment as expected");
 }
 
-/***************
- * HeaderTest *
- ***************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests serialization/deserialization of LoRaWAN headers (the LorawanMacHeader and
+ * LoraFrameHeader classes) on packets
+ */
 class HeaderTest : public TestCase
 {
   public:
-    HeaderTest();
-    ~HeaderTest() override;
+    HeaderTest();           //!< Default constructor
+    ~HeaderTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -404,29 +411,60 @@ HeaderTest::DoRun()
                           "Removed header's MAC command contents don't match");
 }
 
-/*******************
- * ReceivePathTest *
- *******************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests a number of cases related to SimpleGatewayLoraPhy's parallel reception paths
+ *
+ * @todo The test is commented out. To be fixed.
+ */
 class ReceivePathTest : public TestCase
 {
   public:
-    ReceivePathTest();
-    ~ReceivePathTest() override;
+    ReceivePathTest();           //!< Default constructor
+    ~ReceivePathTest() override; //!< Destructor
 
   private:
     void DoRun() override;
+    /**
+     * Reset counters and gateway PHY for new sub test case.
+     */
     void Reset();
+    /**
+     * Callback for tracing OccupiedReceptionPaths.
+     *
+     * @param oldValue The old value.
+     * @param newValue The new value.
+     */
     void OccupiedReceptionPaths(int oldValue, int newValue);
+    /**
+     * Callback for tracing LostPacketBecauseNoMoreReceivers.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void NoMoreDemodulators(Ptr<const Packet> packet, uint32_t node);
+    /**
+     * Callback for tracing LostPacketBecauseInterference.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void Interference(Ptr<const Packet> packet, uint32_t node);
+    /**
+     * Callback for tracing ReceivedPacket.
+     *
+     * @param packet The packet received.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void ReceivedPacket(Ptr<const Packet> packet, uint32_t node);
 
-    Ptr<GatewayLoraPhy> gatewayPhy;
-    int m_noMoreDemodulatorsCalls = 0;
-    int m_interferenceCalls = 0;
-    int m_receivedPacketCalls = 0;
-    int m_maxOccupiedReceptionPaths = 0;
+    Ptr<GatewayLoraPhy> gatewayPhy; //!< PHY layer of a gateway to be tested
+
+    int m_noMoreDemodulatorsCalls = 0;   //!< Counter for LostPacketBecauseNoMoreReceivers calls
+    int m_interferenceCalls = 0;         //!< Counter for LostPacketBecauseInterference calls
+    int m_receivedPacketCalls = 0;       //!< Counter for ReceivedPacket calls
+    int m_maxOccupiedReceptionPaths = 0; //!< Max number of concurrent OccupiedReceptionPaths
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -1054,15 +1092,16 @@ ReceivePathTest::DoRun()
     NS_TEST_EXPECT_MSG_EQ(m_maxOccupiedReceptionPaths, 1, "Unexpected value");
 }
 
-/**************************
- * LogicalChannelTest *
- **************************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests functionality of the LogicalChannel, SubBand and LogicalChannelManager classes
+ */
 class LogicalChannelTest : public TestCase
 {
   public:
-    LogicalChannelTest();
-    ~LogicalChannelTest() override;
+    LogicalChannelTest();           //!< Default constructor
+    ~LogicalChannelTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -1171,21 +1210,20 @@ LogicalChannelTest::DoRun()
     // Other bands are not affected by this transmission
     NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitingTime(channel3),
                           Time(0),
-                          "Waiting time affects other subbands");
-    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitingTime(channel4),
-                          Time(0),
-                          "Waiting time affects other subbands");
+                          "Wait time affects other subbands");
 }
 
-/*****************
- * TimeOnAirTest *
- *****************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests the correctness of the LoraPhy::GetTimeOnAir calculator against a number of pre-sourced
+ * time values of known scenarios
+ */
 class TimeOnAirTest : public TestCase
 {
   public:
-    TimeOnAirTest();
-    ~TimeOnAirTest() override;
+    TimeOnAirTest();           //!< Default constructor
+    ~TimeOnAirTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -1288,46 +1326,88 @@ TimeOnAirTest::DoRun()
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 2.301952, 0.0001, "Unexpected duration");
 }
 
-/**************************
- * PhyConnectivityTest *
- **************************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests sending packets over a LoRa physical channel between multiple devices and the resulting
+ * possible outcomes
+ */
 class PhyConnectivityTest : public TestCase
 {
   public:
-    PhyConnectivityTest();
-    ~PhyConnectivityTest() override;
+    PhyConnectivityTest();           //!< Default constructor
+    ~PhyConnectivityTest() override; //!< Destructor
+
+    /**
+     * Reset counters and end devices' PHYs for new sub test case.
+     */
     void Reset();
+
+    /**
+     * Callback for tracing ReceivedPacket.
+     *
+     * @param packet The packet received.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void ReceivedPacket(Ptr<const Packet> packet, uint32_t node);
+
+    /**
+     * Callback for tracing LostPacketBecauseUnderSensitivity.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void UnderSensitivity(Ptr<const Packet> packet, uint32_t node);
+
+    /**
+     * Callback for tracing LostPacketBecauseInterference.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void Interference(Ptr<const Packet> packet, uint32_t node);
+
+    /**
+     * Callback for tracing LostPacketBecauseWrongFrequency.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void WrongFrequency(Ptr<const Packet> packet, uint32_t node);
+
+    /**
+     * Callback for tracing LostPacketBecauseWrongSpreadingFactor.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
     void WrongSf(Ptr<const Packet> packet, uint32_t node);
 
     /**
      * Compare two packets to check if they are equal.
      *
-     * \param packet1 A first packet.
-     * \param packet2 A second packet.
-     * \return True if their unique identifiers are equal,
-     * \return false otherwise.
+     * @param packet1 A first packet.
+     * @param packet2 A second packet.
+     * @return True if their unique identifiers are equal,
+     * @return false otherwise.
      */
     bool IsSamePacket(Ptr<Packet> packet1, Ptr<Packet> packet2);
 
   private:
     void DoRun() override;
-    Ptr<LoraChannel> channel;
-    Ptr<EndDeviceLoraPhy> edPhy1;
-    Ptr<EndDeviceLoraPhy> edPhy2;
-    Ptr<GatewayLoraPhy> gwPhy1;
-    Ptr<GatewayLoraPhy> gwPhy2;
 
-    Ptr<Packet> m_latestReceivedPacket;
-    int m_receivedPacketCalls = 0;
-    int m_underSensitivityCalls = 0;
-    int m_interferenceCalls = 0;
-    int m_wrongSfCalls = 0;
-    int m_wrongFrequencyCalls = 0;
+    Ptr<LoraChannel> channel;     //!< The LoRa channel used for tests
+    Ptr<EndDeviceLoraPhy> edPhy1; //!< The first end device's PHY layer used in tests
+    Ptr<EndDeviceLoraPhy> edPhy2; //!< The second end device's PHY layer used in tests
+    Ptr<GatewayLoraPhy> gwPhy1;   //!< The first gateway's PHY layer used in tests
+    Ptr<GatewayLoraPhy> gwPhy2;   //!< The second gateway's PHY layer used in tests
+
+    Ptr<Packet> m_latestReceivedPacket; //!< Pointer to track the last received packet
+    int m_receivedPacketCalls = 0;      //!< Counter for ReceivedPacket calls
+    int m_underSensitivityCalls = 0;    //!< Counter for LostPacketBecauseUnderSensitivity calls
+    int m_interferenceCalls = 0;        //!< Counter for LostPacketBecauseInterference calls
+    int m_wrongSfCalls = 0;             //!< Counter for LostPacketBecauseWrongSpreadingFactor calls
+    int m_wrongFrequencyCalls = 0;      //!< Counter for LostPacketBecauseWrongFrequency calls
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -1344,7 +1424,7 @@ PhyConnectivityTest::~PhyConnectivityTest()
 void
 PhyConnectivityTest::ReceivedPacket(Ptr<const Packet> packet, uint32_t node)
 {
-    NS_LOG_FUNCTION(packet << (unsigned)node);
+    NS_LOG_FUNCTION(packet << node);
 
     m_receivedPacketCalls++;
 
@@ -1354,7 +1434,7 @@ PhyConnectivityTest::ReceivedPacket(Ptr<const Packet> packet, uint32_t node)
 void
 PhyConnectivityTest::UnderSensitivity(Ptr<const Packet> packet, uint32_t node)
 {
-    NS_LOG_FUNCTION(packet << (unsigned)node);
+    NS_LOG_FUNCTION(packet << node);
 
     m_underSensitivityCalls++;
 }
@@ -1362,7 +1442,7 @@ PhyConnectivityTest::UnderSensitivity(Ptr<const Packet> packet, uint32_t node)
 void
 PhyConnectivityTest::Interference(Ptr<const Packet> packet, uint32_t node)
 {
-    NS_LOG_FUNCTION(packet << (unsigned)node);
+    NS_LOG_FUNCTION(packet << node);
 
     m_interferenceCalls++;
 }
@@ -1370,7 +1450,7 @@ PhyConnectivityTest::Interference(Ptr<const Packet> packet, uint32_t node)
 void
 PhyConnectivityTest::WrongSf(Ptr<const Packet> packet, uint32_t node)
 {
-    NS_LOG_FUNCTION(packet << (unsigned)node);
+    NS_LOG_FUNCTION(packet << node);
 
     m_wrongSfCalls++;
 }
@@ -1378,7 +1458,7 @@ PhyConnectivityTest::WrongSf(Ptr<const Packet> packet, uint32_t node)
 void
 PhyConnectivityTest::WrongFrequency(Ptr<const Packet> packet, uint32_t node)
 {
-    NS_LOG_FUNCTION(packet << (unsigned)node);
+    NS_LOG_FUNCTION(packet << node);
 
     m_wrongFrequencyCalls++;
 }
@@ -1511,7 +1591,7 @@ PhyConnectivityTest::DoRun()
     uint8_t buffer[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     Ptr<Packet> packet = Create<Packet>(buffer, 10);
     LoraFrameHeader fHdr;
-    packet->AddHeader(fHdr); // Default address is accepred by devices
+    packet->AddHeader(fHdr); // Default address is accepted by devices
     LorawanMacHeader mHdr;
     mHdr.SetFType(LorawanMacHeader::UNCONFIRMED_DATA_DOWN);
     packet->AddHeader(mHdr); // Currently, gateways don't care about UL/DL
@@ -1556,11 +1636,12 @@ PhyConnectivityTest::DoRun()
     NS_TEST_EXPECT_MSG_EQ(
         m_receivedPacketCalls,
         1,
-        "Packet was received by a ED PHY in SLEEP mode"); // All ED PHYs in Standby except one
+        "Packet was received by a PHY in SLEEP mode"); // All PHYs in Standby except the sender
 
     Simulator::Destroy();
 
-    // Packet that arrives under sensitivity is received correctly if SF increases
+    // Packet that arrives under sensitivity is received correctly if the spreading factor
+    // increases
 
     Reset();
     txParams.sf = 7;
@@ -1581,11 +1662,11 @@ PhyConnectivityTest::DoRun()
     NS_TEST_EXPECT_MSG_EQ(
         m_underSensitivityCalls,
         1,
-        "Packet that should have been lost because of low receive power was recevied");
+        "Packet that should have been lost because of low receive power was received");
 
     Simulator::Destroy();
 
-    // Try again using a packet with higher SF
+    // Try again using a packet with higher spreading factor
 
     Reset();
     txParams.sf = 8;
@@ -1657,7 +1738,7 @@ PhyConnectivityTest::DoRun()
 
     Simulator::Destroy();
 
-    // Packets can be lost because the PHY is not listening for the right SF
+    // Packets can be lost because the PHY is not listening for the right spreading factor
 
     Reset();
     txParams.sf = 8; // Send with 8, listening for 12
@@ -1668,7 +1749,8 @@ PhyConnectivityTest::DoRun()
 
     NS_TEST_EXPECT_MSG_EQ(m_wrongSfCalls,
                           2,
-                          "Packets were received even though PHY was listening for a different SF");
+                          "Packets were received even though PHY was listening for a different "
+                          "spreading factor.");
 
     Simulator::Destroy();
 
@@ -1739,15 +1821,18 @@ PhyConnectivityTest::DoRun()
     Simulator::Destroy();
 }
 
-/*****************
- * LorawanMacTest *
- *****************/
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests the functionalities of the MAC layer of LoRaWAN devices
+ *
+ * @todo Not implemented yet.
+ */
 class LorawanMacTest : public TestCase
 {
   public:
-    LorawanMacTest();
-    ~LorawanMacTest() override;
+    LorawanMacTest();           //!< Default constructor
+    ~LorawanMacTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -1755,7 +1840,7 @@ class LorawanMacTest : public TestCase
 
 // Add some help text to this case to describe what it is intended to test
 LorawanMacTest::LorawanMacTest()
-    : TestCase("Verify that the MAC layer of EDs behaves as expected")
+    : TestCase("Verify that the MAC layer of end devices behaves as expected")
 {
 }
 
@@ -1772,25 +1857,669 @@ LorawanMacTest::DoRun()
     NS_LOG_DEBUG("LorawanMacTest");
 }
 
-/**************
- * Test Suite *
- **************/
+/**
+ * @ingroup lorawan
+ *
+ * It tests the functionalities of LoRaWAN MAC commands received by devices.
+ *
+ * This means testing that (i) settings in the downlink MAC commands are correctly applied/rejected
+ * by the device, and that (ii) the correct answer (if expected) is produced by the device.
+ */
+class MacCommandTest : public TestCase
+{
+  public:
+    MacCommandTest();           //!< Default constructor
+    ~MacCommandTest() override; //!< Destructor
 
-// The TestSuite class names the TestSuite, identifies what type of TestSuite,
-// and enables the TestCases to be run. Typically, only the constructor for
-// this class must be defined
+  private:
+    /**
+     * Have this class' MAC layer receive a downlink packet carrying the input MAC command.
+     * After, trigger a new empty uplink packet send that can then be used to examine the MAC
+     * command answers in the header.
+     *
+     * @tparam T  \explicit The type of MAC command to create.
+     * @tparam Ts \deduced Types of the constructor arguments.
+     * @param  [in] args MAC command constructor arguments.
+     * @return The list of MAC commands produced by the device as an answer.
+     */
+    template <typename T, typename... Ts>
+    std::list<Ptr<MacCommand>> RunMacCommand(Ts&&... args);
 
+    /**
+     * This function resets the state of the MAC layer used for tests. Use it before each call
+     * of RunMacCommand. Otherwise, on consecutive calls the MAC layer will not send due to
+     * duty-cycle limitations.
+     */
+    void Reset();
+
+    void DoRun() override;
+
+    Ptr<ClassAEndDeviceLorawanMac> m_mac; //!< The end device's MAC layer used in tests.
+};
+
+MacCommandTest::MacCommandTest()
+    : TestCase("Test functionality of MAC commands when received by a device")
+{
+}
+
+MacCommandTest::~MacCommandTest()
+{
+    m_mac = nullptr;
+}
+
+template <typename T, typename... Ts>
+std::list<Ptr<MacCommand>>
+MacCommandTest::RunMacCommand(Ts&&... args)
+{
+    Ptr<Packet> pkt;
+    LoraFrameHeader fhdr;
+    LorawanMacHeader mhdr;
+    // Prepare DL packet with input command
+    pkt = Create<Packet>(0);
+    fhdr.SetAsDownlink();
+    auto cmd = Create<T>(args...);
+    fhdr.AddCommand(cmd);
+    pkt->AddHeader(fhdr);
+    mhdr.SetFType(LorawanMacHeader::UNCONFIRMED_DATA_DOWN);
+    pkt->AddHeader(mhdr);
+    pkt->AddPaddingAtEnd(4); // MIC
+    // Trigger MAC layer reception
+    DynamicCast<EndDeviceLoraPhy>(m_mac->GetPhy())
+        ->SwitchToStandby(); // usually done as we open Rx windows
+    m_mac->Receive(pkt);
+    // Trigger MAC layer send
+    pkt = Create<Packet>(0);
+    m_mac->Send(pkt);
+    // Retrieve uplink MAC commands
+    pkt->RemoveAtEnd(4); // MIC
+    pkt->RemoveHeader(mhdr);
+    fhdr.SetAsUplink();
+    pkt->RemoveHeader(fhdr);
+    return fhdr.GetCommands();
+}
+
+void
+MacCommandTest::Reset()
+{
+    // Reset MAC state
+    LorawanMacHelper macHelper;
+    macHelper.SetRegion(LorawanMacHelper::EU);
+    macHelper.SetType("ns3::ClassAEndDeviceLorawanMac");
+    /// @todo Create should not require a node in input.
+    m_mac = DynamicCast<ClassAEndDeviceLorawanMac>(macHelper.Install(nullptr));
+    NS_TEST_EXPECT_MSG_NE(m_mac, nullptr, "Failed to initialize MAC layer object.");
+    auto phy = CreateObject<EndDeviceLoraPhy>();
+    phy->SetChannel(CreateObject<LoraChannel>());
+    phy->SetMobility(CreateObject<ConstantPositionMobilityModel>());
+    m_mac->SetPhy(phy);
+    m_mac->Initialize();
+}
+
+void
+MacCommandTest::DoRun()
+{
+    NS_LOG_DEBUG("MacCommandTest");
+
+    Reset();
+    // LinkCheckAns: get connectivity metrics of last uplink LinkCheckReq command
+    {
+        uint8_t margin = 20; // best reception margin [dB] from demodulation floor
+        uint8_t gwCnt = 3;   // number of gateways that received last uplink
+        auto answers = RunMacCommand<LinkCheckAns>(margin, gwCnt);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetLastKnownLinkMarginDb()),
+                              unsigned(margin),
+                              "m_lastKnownMarginDb differs from Margin field of LinkCheckAns");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetLastKnownGatewayCount()),
+                              unsigned(gwCnt),
+                              "m_lastKnownGatewayCount differs GwCnt field of LinkCheckAns");
+        NS_TEST_EXPECT_MSG_EQ(answers.size(),
+                              0,
+                              "Unexpected uplink MAC command answer(s) to LinkCheckAns");
+    }
+
+    Reset();
+    // LinkAdrReq: change data rate, TX power, redundancy, or channel mask
+    {
+        uint8_t dataRate = 5;
+        uint8_t txPower = 2;
+        uint16_t chMask = 0b101;
+        uint8_t chMaskCntl = 0;
+        uint8_t nbTrans = 13;
+        auto answers = RunMacCommand<LinkAdrReq>(dataRate, txPower, chMask, chMaskCntl, nbTrans);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
+                              unsigned(dataRate),
+                              "m_dataRate does not match DataRate field of LinkAdrReq");
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+                              14 - txPower * 2,
+                              "m_txPowerDbm does not match txPower field of LinkAdrReq");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetNumberOfTransmissions()),
+                              unsigned(nbTrans),
+                              "m_nbTrans does not match nbTrans field of LinkAdrReq");
+        auto chanMgr = m_mac->GetLogicalChannelManager();
+        for (size_t i = 0; i < 16; i++)
+        {
+            const auto& c = chanMgr->GetChannel(i + 16 * chMaskCntl);
+            bool actual = (c) ? c->IsEnabledForUplink() : false;
+            bool expected = (chMask & 0b1 << i);
+            NS_TEST_EXPECT_MSG_EQ(actual, expected, "Channel " << i << " state != chMask");
+        }
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto laa = DynamicCast<LinkAdrAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(laa, nullptr, "LinkAdrAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetChannelMaskAck(), true, "ChannelMaskAck expected to be true");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetDataRateAck(), true, "DataRateAck expected to be true");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetPowerAck(), true, "PowerAck expected to be true");
+    }
+
+    Reset();
+    // LinkAdrReq: ADR bit off, only change channel mask
+    {
+        uint8_t dataRate = 5;
+        uint8_t txPower = 2;
+        uint16_t chMask = 0b010;
+        uint8_t chMaskCntl = 0;
+        uint8_t nbTrans = 13;
+        m_mac->SetAttribute("ADR", BooleanValue(false));
+        auto answers = RunMacCommand<LinkAdrReq>(dataRate, txPower, chMask, chMaskCntl, nbTrans);
+        NS_TEST_EXPECT_MSG_NE(unsigned(m_mac->GetDataRate()),
+                              unsigned(dataRate),
+                              "m_dataRate expected to differ from DataRate field of LinkAdrReq");
+        NS_TEST_EXPECT_MSG_NE(m_mac->GetTransmissionPower(),
+                              14 - txPower * 2,
+                              "m_txPowerDbm expected to not match txPower field of LinkAdrReq");
+        NS_TEST_EXPECT_MSG_NE(unsigned(m_mac->GetNumberOfTransmissions()),
+                              unsigned(nbTrans),
+                              "m_nbTrans expected to differ from nbTrans field of LinkAdrReq");
+        auto chanMgr = m_mac->GetLogicalChannelManager();
+        for (size_t i = 0; i < 16; i++)
+        {
+            const auto& c = chanMgr->GetChannel(i + 16 * chMaskCntl);
+            bool actual = (c) ? c->IsEnabledForUplink() : false;
+            bool expected = (chMask & 0b1 << i);
+            NS_TEST_EXPECT_MSG_EQ(actual, expected, "Channel " << i << " state != chMask");
+        }
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto laa = DynamicCast<LinkAdrAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(laa, nullptr, "LinkAdrAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetChannelMaskAck(), true, "ChannelMaskAck expected to be true");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetDataRateAck(), false, "DataRateAck expected to be false");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetPowerAck(), false, "PowerAck expected to be false");
+    }
+
+    Reset();
+    // LinkAdrReq: invalid chMask, data rate and power
+    { // WARNING: default values are manually set here
+        uint8_t dataRate = 12;
+        uint8_t txPower = 8;
+        uint16_t chMask = 0b0;
+        uint8_t chMaskCntl = 0;
+        uint8_t nbTrans = 6;
+        auto answers = RunMacCommand<LinkAdrReq>(dataRate, txPower, chMask, chMaskCntl, nbTrans);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
+                              0,
+                              "m_dataRate expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+                              14,
+                              "m_txPowerDbm expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetNumberOfTransmissions()),
+                              1,
+                              "m_nbTrans expected to be default value");
+        auto chanMgr = m_mac->GetLogicalChannelManager();
+        for (size_t i = 0; i < 16; i++)
+        {
+            const auto& c = chanMgr->GetChannel(i + 16 * chMaskCntl);
+            bool actual = (c) ? c->IsEnabledForUplink() : false;
+            bool expected = (uint16_t(0b111) & 0b1 << i);
+            NS_TEST_EXPECT_MSG_EQ(actual, expected, "Channel " << i << " state != default");
+        }
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto laa = DynamicCast<LinkAdrAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(laa, nullptr, "LinkAdrAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetChannelMaskAck(), false, "ChannelMaskAck != false");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetDataRateAck(), false, "DataRateAck expected to be false");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetPowerAck(), false, "PowerAck expected to be false");
+    }
+
+    Reset();
+    // LinkAdrReq: invalid chMask, valid data rate and power
+    { // WARNING: default values are manually set here
+        uint8_t dataRate = 1;
+        uint8_t txPower = 7;
+        uint16_t chMask = 0b1000; // enable only non-exisitng channel
+        uint8_t chMaskCntl = 0;
+        uint8_t nbTrans = 3;
+        auto answers = RunMacCommand<LinkAdrReq>(dataRate, txPower, chMask, chMaskCntl, nbTrans);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
+                              0,
+                              "m_dataRate expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+                              14,
+                              "m_txPowerDbm expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetNumberOfTransmissions()),
+                              1,
+                              "m_nbTrans expected to be default value");
+        auto chanMgr = m_mac->GetLogicalChannelManager();
+        for (size_t i = 0; i < 16; i++)
+        {
+            const auto& c = chanMgr->GetChannel(i + 16 * chMaskCntl);
+            bool actual = (c) ? c->IsEnabledForUplink() : false;
+            bool expected = (uint16_t(0b111) & 0b1 << i);
+            NS_TEST_EXPECT_MSG_EQ(actual, expected, "Channel " << i << " state != default");
+        }
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto laa = DynamicCast<LinkAdrAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(laa, nullptr, "LinkAdrAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetChannelMaskAck(), false, "ChannelMaskAck != false");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetDataRateAck(), true, "DataRateAck expected to be true");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetPowerAck(), true, "PowerAck expected to be true");
+    }
+
+    Reset();
+    // LinkAdrReq: fringe parameter values
+    { // WARNING: default values are manually set here
+        uint8_t dataRate = 0xF;
+        uint8_t txPower = 0xF;  // 0x0F ignores config
+        uint16_t chMask = 0b0;  // should be ignored because chMaskCntl is 6
+        uint8_t chMaskCntl = 6; // all channels on
+        uint8_t nbTrans = 0;    // restore default 1
+        // Set device params to values different from default
+        m_mac->SetDataRate(3);
+        m_mac->SetTransmissionPower(12);
+        m_mac->SetNumberOfTransmissions(15);
+        auto chanMgr = m_mac->GetLogicalChannelManager();
+        chanMgr->GetChannel(0)->DisableForUplink();
+        auto answers = RunMacCommand<LinkAdrReq>(dataRate, txPower, chMask, chMaskCntl, nbTrans);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
+                              3,
+                              "m_dataRate expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+                              12,
+                              "m_txPowerDbm expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetNumberOfTransmissions()),
+                              1,
+                              "m_nbTrans expected to be default value");
+        for (size_t i = 0; i < 16; i++)
+        {
+            const auto& c = chanMgr->GetChannel(i);
+            bool actual = (c) ? c->IsEnabledForUplink() : false;
+            bool expected = (uint16_t(0b111) & 0b1 << i);
+            NS_TEST_EXPECT_MSG_EQ(actual, expected, "Channel " << i << " state != default");
+        }
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto laa = DynamicCast<LinkAdrAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(laa, nullptr, "LinkAdrAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetChannelMaskAck(), true, "ChannelMaskAck != true");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetDataRateAck(), true, "DataRateAck expected to be true");
+        NS_TEST_EXPECT_MSG_EQ(laa->GetPowerAck(), true, "PowerAck expected to be true");
+    }
+
+    Reset();
+    // DutyCycleReq: duty cycle to 100%
+    {
+        uint8_t maxDutyCycle = 0;
+        auto answers = RunMacCommand<DutyCycleReq>(maxDutyCycle);
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetAggregatedDutyCycle(),
+                              1 / std::pow(2, maxDutyCycle),
+                              "m_aggregatedDutyCycle != 1");
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto dca = DynamicCast<DutyCycleAns>(*(answers.begin()));
+        NS_TEST_EXPECT_MSG_NE(dca, nullptr, "DutyCycleAns was expected, cmd type cast failed");
+    }
+
+    Reset();
+    // DutyCycleReq: duty cycle to 12.5%
+    {
+        uint8_t maxDutyCycle = 3;
+        auto answers = RunMacCommand<DutyCycleReq>(maxDutyCycle);
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetAggregatedDutyCycle(),
+                              1 / std::pow(2, maxDutyCycle),
+                              "m_aggregatedDutyCycle != 1");
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto dca = DynamicCast<DutyCycleAns>(*(answers.begin()));
+        NS_TEST_EXPECT_MSG_NE(dca, nullptr, "DutyCycleAns was expected, cmd type cast failed");
+    }
+
+    Reset();
+    // RxParamSetupReq: set rx1Dr, rx2Dr, frequency
+    {
+        uint8_t rx1DrOffset = 5;
+        uint8_t rx2DataRate = 5;
+        double frequencyHz = 863500000;
+        m_mac->SetDataRate(5);
+        auto answers = RunMacCommand<RxParamSetupReq>(rx1DrOffset, rx2DataRate, frequencyHz);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetFirstReceiveWindowDataRate()),
+                              unsigned(5 - rx1DrOffset),
+                              "Rx1DataRate does not match rx1DrOffset from RxParamSetupReq");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetSecondReceiveWindowDataRate()),
+                              unsigned(rx2DataRate),
+                              "Rx2DataRate does not match rx2DataRate from RxParamSetupReq");
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetSecondReceiveWindowFrequency(),
+                              frequencyHz,
+                              "Rx2 frequency does not match frequency from RxParamSetupReq");
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto rpsa = DynamicCast<RxParamSetupAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(rpsa, nullptr, "RxParamSetupAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(rpsa->GetRx1DrOffsetAck(), true, "Rx1DrOffsetAck != true");
+        NS_TEST_EXPECT_MSG_EQ(rpsa->GetRx2DataRateAck(), true, "Rx2DataRateAck != true");
+        NS_TEST_EXPECT_MSG_EQ(rpsa->GetChannelAck(), true, "ChannelAck expected to be true");
+    }
+
+    Reset();
+    // RxParamSetupReq: invalid rx1Dr, rx2Dr, frequency
+    { // WARNING: default values are manually set here
+        uint8_t rx1DrOffset = 6;
+        uint8_t rx2DataRate = 12;
+        double frequencyHz = 871000000;
+        m_mac->SetDataRate(5);
+        auto answers = RunMacCommand<RxParamSetupReq>(rx1DrOffset, rx2DataRate, frequencyHz);
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetFirstReceiveWindowDataRate()),
+                              5,
+                              "Rx1DataRate expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetSecondReceiveWindowDataRate()),
+                              0,
+                              "Rx2DataRate expected to be default value");
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetSecondReceiveWindowFrequency(),
+                              869525000,
+                              "Rx2 frequency expected to be default value");
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto rpsa = DynamicCast<RxParamSetupAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(rpsa, nullptr, "RxParamSetupAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(rpsa->GetRx1DrOffsetAck(), false, "Rx1DrOffsetAck != false");
+        NS_TEST_EXPECT_MSG_EQ(rpsa->GetRx2DataRateAck(), false, "Rx2DataRateAck != false");
+        NS_TEST_EXPECT_MSG_EQ(rpsa->GetChannelAck(), false, "ChannelAck expected to be false");
+    }
+
+    Reset();
+    // DevStatusReq: get default values
+    { // WARNING: default values are manually set here
+        auto answers = RunMacCommand<DevStatusReq>();
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto dsa = DynamicCast<DevStatusAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(dsa, nullptr, "DevStatusAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(dsa->GetBattery()), 0, "Battery expected == 0 (ext power)");
+        NS_TEST_EXPECT_MSG_EQ(unsigned(dsa->GetMargin()), 31, "Margin expected to be 31 (default)");
+    }
+
+    Reset();
+    // NewChannelReq: add a new channel
+    {
+        uint8_t chIndex = 4;
+        double frequencyHz = 865100000;
+        uint8_t minDataRate = 1;
+        uint8_t maxDataRate = 4;
+        auto answers = RunMacCommand<NewChannelReq>(chIndex, frequencyHz, minDataRate, maxDataRate);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        auto c = m_mac->GetLogicalChannelManager()->GetChannel(chIndex);
+        NS_TEST_ASSERT_MSG_NE(c, nullptr, "Channel at chIndex slot expected not to be nullptr");
+        NS_TEST_EXPECT_MSG_EQ(c->GetFrequency(),
+                              frequencyHz,
+                              "Channel frequency expected to equal NewChannelReq frequency");
+        NS_TEST_EXPECT_MSG_EQ(c->GetMinimumDataRate(),
+                              unsigned(minDataRate),
+                              "Channel minDataRate expected to equal NewChannelReq minDataRate");
+        NS_TEST_EXPECT_MSG_EQ(c->GetMaximumDataRate(),
+                              unsigned(maxDataRate),
+                              "Channel maxDataRate expected to equal NewChannelReq maxDataRate");
+        auto nca = DynamicCast<NewChannelAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(nca, nullptr, "NewChannelAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(nca->GetDataRateRangeOk(), true, "DataRateRangeOk != true");
+        NS_TEST_EXPECT_MSG_EQ(nca->GetChannelFrequencyOk(), true, "ChannelFrequencyOk != true");
+    }
+
+    Reset();
+    // NewChannelReq: invalid new channel
+    { // WARNING: default values are manually set here
+        uint8_t chIndex = 1;
+        double frequencyHz = 862000000;
+        uint8_t minDataRate = 14;
+        uint8_t maxDataRate = 13;
+        auto answers = RunMacCommand<NewChannelReq>(chIndex, frequencyHz, minDataRate, maxDataRate);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        double defaultFrequenciesHz[3] = {868100000, 868300000, 868500000};
+        auto chanMgr = m_mac->GetLogicalChannelManager();
+        for (size_t i = 0; i < 16; i++)
+        {
+            const auto& c = chanMgr->GetChannel(i);
+            if (i > 2)
+            {
+                NS_TEST_ASSERT_MSG_EQ(c, nullptr, "Channel " << i << "expected to be nullptr");
+                continue;
+            }
+            NS_TEST_EXPECT_MSG_EQ(c->GetFrequency(),
+                                  defaultFrequenciesHz[i],
+                                  "Channel frequency expected to equal NewChannelReq frequency");
+            NS_TEST_EXPECT_MSG_EQ(unsigned(c->GetMinimumDataRate()),
+                                  0,
+                                  "Channel " << i << " minDataRate expected to be default");
+            NS_TEST_EXPECT_MSG_EQ(unsigned(c->GetMaximumDataRate()),
+                                  5,
+                                  "Channel " << i << " maxDataRate expected to be default");
+            NS_TEST_EXPECT_MSG_EQ(c->IsEnabledForUplink(),
+                                  true,
+                                  "Channel " << i << " state expected to be active by default");
+        }
+        auto nca = DynamicCast<NewChannelAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(nca, nullptr, "NewChannelAns was expected, cmd type cast failed");
+        NS_TEST_EXPECT_MSG_EQ(nca->GetDataRateRangeOk(), false, "DataRateRangeOk != false");
+        NS_TEST_EXPECT_MSG_EQ(nca->GetChannelFrequencyOk(), false, "ChannelFrequencyOk != false");
+    }
+}
+
+/**
+ * @ingroup lorawan
+ *
+ * It tests the correct execution of the ADR backoff procedure of LoRaWAN devices.
+ * (See, LoRaWAN L2 1.0.4 Specifications (2020), Section 4.3.1.1)
+ */
+class AdrBackoffTest : public TestCase
+{
+  public:
+    AdrBackoffTest();           //!< Default constructor
+    ~AdrBackoffTest() override; //!< Destructor
+
+  private:
+    /**
+     * Create and send an empty app payload unconfirmed frame through the MAC layer to increment
+     * of the FCnt and ADRACKCnt and eventually activate the ADR backoff procedure
+     * configurations of the MAC layer. The packet is sent after a delay (simulated time is
+     * fast-forwarded to the event) such that the device does not incur any duty-cycle
+     * limitation. The sent packet FHDR is returned as argument for validation purposes.
+     *
+     * @param after Delay to schedule the packet after to avoid duty-cycle limitations
+     * @param fhdr [out] FHDR of the constructed frame passed to PHY by the MAC
+     */
+    void SendUplink(Time after, LoraFrameHeader& fhdr);
+
+    /**
+     * Create and schedule an empty payload downlink destined for the LoRaWAN MAC. This is used
+     * to test resetting the ADR backoff procedure.
+     *
+     * @note This does not call Simulator::Run(), enabling preemptive scheduling
+     *
+     * @param after Delay to schedule the packet after to sync with rx windows
+     */
+    void ScheduleDownlink(Time after);
+
+    /**
+     * This function resets the simulation and device MAC layer, use before test sub-cases.
+     */
+    void Reset();
+
+    void DoRun() override;
+
+    Ptr<ClassAEndDeviceLorawanMac> m_mac; //!< The end device's MAC layer used in tests.
+};
+
+AdrBackoffTest::AdrBackoffTest()
+    : TestCase("Test the ADR backoff procedure of the LoRaWAN MAC protocol")
+{
+}
+
+AdrBackoffTest::~AdrBackoffTest()
+{
+    m_mac = nullptr;
+}
+
+void
+AdrBackoffTest::SendUplink(Time after, LoraFrameHeader& fhdr)
+{
+    Ptr<Packet> pkt;
+    LorawanMacHeader mhdr;
+    // Send packet through the MAC layer
+    pkt = Create<Packet>(0);
+    Simulator::Schedule(after, &ClassAEndDeviceLorawanMac::Send, m_mac, pkt);
+    Simulator::Run();
+    pkt->RemoveAtEnd(4); // MIC
+    // Retrieve uplink FHDR
+    pkt->RemoveHeader(mhdr);
+    fhdr.SetAsUplink();
+    pkt->RemoveHeader(fhdr);
+    NS_LOG_LOGIC("Frame Header: " << fhdr);
+}
+
+void
+AdrBackoffTest::ScheduleDownlink(Time after)
+{
+    Ptr<Packet> pkt;
+    LoraFrameHeader fhdr;
+    LorawanMacHeader mhdr;
+    // Prepare DL packet
+    pkt = Create<Packet>(0);
+    fhdr.SetAsDownlink();
+    pkt->AddHeader(fhdr);
+    mhdr.SetFType(LorawanMacHeader::UNCONFIRMED_DATA_DOWN);
+    pkt->AddHeader(mhdr);
+    pkt->AddPaddingAtEnd(4); // MIC
+    // Schedule MAC layer reception
+    Simulator::Schedule(after, &ClassAEndDeviceLorawanMac::Receive, m_mac, pkt);
+}
+
+void
+AdrBackoffTest::Reset()
+{
+    Simulator::Destroy();
+    // Reset MAC state
+    LorawanMacHelper macHelper;
+    macHelper.SetRegion(LorawanMacHelper::EU);
+    macHelper.SetType("ns3::ClassAEndDeviceLorawanMac");
+    /// @todo Install should not require a node in input.
+    m_mac = DynamicCast<ClassAEndDeviceLorawanMac>(macHelper.Install(nullptr));
+    NS_TEST_EXPECT_MSG_NE(m_mac, nullptr, "Failed to initialize MAC layer object.");
+    auto phy = CreateObject<EndDeviceLoraPhy>();
+    phy->SetChannel(CreateObject<LoraChannel>());
+    phy->SetMobility(CreateObject<ConstantPositionMobilityModel>());
+    m_mac->SetPhy(phy);
+    m_mac->Initialize();
+}
+
+void
+AdrBackoffTest::DoRun()
+{
+    NS_LOG_DEBUG("AdrBackoffTest");
+
+    Reset();
+    // Full ADR Backoff procedure
+    {
+        LoraFrameHeader fhdr;
+        auto lcm = m_mac->GetLogicalChannelManager();
+        // Custom config to force full ADR backoff
+        {
+            // Tx parameters to furthest settings from default
+            m_mac->SetDataRate(5);
+            m_mac->SetTransmissionPower(0);
+            m_mac->SetNumberOfTransmissions(8);
+            lcm->GetChannel(0)->DisableForUplink();
+            lcm->GetChannel(1)->DisableForUplink();
+            lcm->GetChannel(2)->DisableForUplink();
+            // Provide additional non-default channel for uplinks
+            auto nonDefaultChannel = Create<LogicalChannel>(869850000);
+            lcm->AddChannel(3, nonDefaultChannel);
+        }
+        // 7 total backoff steps: 1 tx power + 5 data rate + 1 nbtrans & channels
+        for (uint32_t fCnt = 0; fCnt <= ADR_ACK_LIMIT + ADR_ACK_DELAY * 7U; ++fCnt)
+        {
+            SendUplink(Minutes(20), fhdr);
+            NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), fCnt, "Unexpected FCnt value in uplink FHDR");
+            NS_TEST_EXPECT_MSG_EQ(fhdr.GetAdrAckReq(),
+                                  fCnt >= ADR_ACK_LIMIT,
+                                  "Unexpected ADRACKReq value in FHDR of uplink fCnt=" << fCnt);
+            uint8_t step = (fCnt >= ADR_ACK_LIMIT) ? (fCnt - ADR_ACK_LIMIT) / ADR_ACK_DELAY : 0;
+            NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+                                  (step > 0) ? 14 : 0,
+                                  "Unexpected tx power on uplink fCnt=" << fCnt);
+            uint8_t expectedDr = (step == 0) ? 5 : (step < 7) ? 5 - (step - 1) : 0;
+            NS_TEST_EXPECT_MSG_EQ(m_mac->GetDataRate(),
+                                  expectedDr,
+                                  "Unexpected data rate on uplink fCnt=" << fCnt);
+            for (uint8_t i = 0; i < 3; ++i)
+            {
+                NS_TEST_EXPECT_MSG_EQ(lcm->GetChannel(i)->IsEnabledForUplink(),
+                                      step >= 7,
+                                      "Unexpected activation state of channel "
+                                          << unsigned(i) << " on uplink fCnt=" << fCnt);
+            }
+            NS_TEST_EXPECT_MSG_EQ(
+                lcm->GetChannel(3)->IsEnabledForUplink(),
+                true,
+                "Unexpected activation state of channel 3 on uplink fCnt=" << fCnt);
+        }
+    }
+
+    Reset();
+    // ADRACKReq back to false after downlink
+    {
+        LoraFrameHeader fhdr;
+        // Trigger ADRACKReq
+        for (uint16_t fCnt = 0; fCnt <= ADR_ACK_LIMIT; ++fCnt)
+        {
+            if (fCnt == ADR_ACK_LIMIT)
+            {
+                // After ADR_ACK_LIMIT uplinks, schedule a downlink in the rx window
+                ScheduleDownlink(Minutes(20) + Seconds(1.2));
+            }
+            SendUplink(Minutes(20), fhdr);
+            NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), fCnt, "Unexpected FCnt value in uplink FHDR");
+            NS_TEST_EXPECT_MSG_EQ(fhdr.GetAdrAckReq(),
+                                  fCnt >= ADR_ACK_LIMIT,
+                                  "Unexpected ADRACKReq value in FHDR of uplink fCnt=" << fCnt);
+        }
+        SendUplink(Minutes(20), fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(),
+                              ADR_ACK_LIMIT + 1,
+                              "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_EXPECT_MSG_EQ(
+            fhdr.GetAdrAckReq(),
+            false,
+            "Unexpected ADRACKReq value in FHDR of uplink fCnt=" << fhdr.GetFCnt());
+    }
+}
+
+/**
+ * @ingroup lorawan
+ *
+ * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
+ * TestCases to be run. Typically, only the constructor for this class must be defined
+ */
 class LorawanTestSuite : public TestSuite
 {
   public:
-    LorawanTestSuite();
+    LorawanTestSuite(); //!< Default constructor
 };
 
 LorawanTestSuite::LorawanTestSuite()
     : TestSuite("lorawan", Type::UNIT)
 {
     // LogComponentEnable("LorawanTestSuite", LOG_LEVEL_DEBUG);
-    //  TestDuration for TestCase can be QUICK, EXTENSIVE or TAKES_FOREVER
+    // LogComponentEnable("LorawanMac", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("BaseEndDeviceLorawanMac", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("ClassAEndDeviceLorawanMac", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("EndDeviceLoraPhy", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("LoraPhy", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("LoraChannel", LOG_LEVEL_DEBUG);
+    // LogComponentEnableAll(LOG_PREFIX_FUNC);
+    // LogComponentEnableAll(LOG_PREFIX_NODE);
+    // LogComponentEnableAll(LOG_PREFIX_TIME);
+
     AddTestCase(new InterferenceTest, Duration::QUICK);
     AddTestCase(new AddressTest, Duration::QUICK);
     AddTestCase(new HeaderTest, Duration::QUICK);
@@ -1798,7 +2527,8 @@ LorawanTestSuite::LorawanTestSuite()
     AddTestCase(new LogicalChannelTest, Duration::QUICK);
     AddTestCase(new TimeOnAirTest, Duration::QUICK);
     AddTestCase(new PhyConnectivityTest, Duration::QUICK);
-    AddTestCase(new LorawanMacTest, Duration::QUICK);
+    AddTestCase(new MacCommandTest, Duration::QUICK);
+    AddTestCase(new AdrBackoffTest, Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2486,7 +2486,6 @@ AdrBackoffTest::Reset()
     LorawanMacHelper macHelper;
     macHelper.SetRegion(LorawanMacHelper::EU);
     macHelper.SetType("ns3::ClassAEndDeviceLorawanMac");
-    /// @todo Install should not require a node in input.
     m_mac = DynamicCast<ClassAEndDeviceLorawanMac>(macHelper.Install(nullptr));
     NS_TEST_EXPECT_MSG_NE(m_mac, nullptr, "Failed to initialize MAC layer object.");
     auto phy = CreateObject<EndDeviceLoraPhy>();
@@ -2581,6 +2580,494 @@ AdrBackoffTest::DoRun()
 /**
  * @ingroup lorawan
  *
+ * It tests the correct execution of the retransmissions in LoRaWAN devices.
+ * (See, LoRaWAN L2 1.0.4 Specifications (2020), Section 4.3.1.3)
+ */
+class RetransmissionTest : public TestCase
+{
+  public:
+    RetransmissionTest();           //!< Default constructor
+    ~RetransmissionTest() override; //!< Destructor
+
+  private:
+    /**
+     * Create and send an empty app payload unconfirmed frame through the MAC layer NbTrans times.
+     * The packet is sent after a delay (simulated time is fast-forwarded to the event) such that
+     * the device does not incur any duty-cycle limitation. The sent packet FHDR is returned as
+     * argument for validation purposes.
+     *
+     * @param after Delay to schedule the packet after to avoid duty-cycle limitations
+     * @param fhdr [out] FHDR of the constructed frame passed to PHY by the MAC
+     */
+    void SendUplink(LoraFrameHeader& fhdr);
+
+    /**
+     * Create and schedule an empty payload downlink destined for the LoRaWAN MAC. This is used
+     * to test stopping the retransmission procedure.
+     *
+     * @note This does not call Simulator::Run(), enabling preemptive scheduling
+     *
+     * @param after Delay to schedule the packet after to sync with rx windows
+     * @param ack Whether to set the ACK flag in the frame header
+     */
+    void ScheduleDownlink(Time after, bool ack = false);
+
+    /**
+     * Callback for tracing MAC layer SentNewPacket.
+     *
+     * @param packet The packet sent.
+     */
+    void MacSentNewPacket(Ptr<const Packet> packet);
+
+    /**
+     * Callback for tracing MAC layer RequiredTransmissions.
+     *
+     * @note This callback only traces confirmed packets, unused otherwise.
+     *
+     * @param transmissions Number of transmissions carried out
+     * @param successful Whether the packet was acknowledged
+     * @param firstAttempt Time of first transmission attempt
+     * @param packet The packet sent
+     */
+    void MacRequiredTransmissions(uint8_t transmissions,
+                                  bool successful,
+                                  Time firstAttempt,
+                                  Ptr<Packet> packet);
+
+    /**
+     * Callback for tracing PHY layer StartSending.
+     *
+     * @param packet The packet being sent.
+     * @param node The sender node id if any, 0 otherwise.
+     */
+    void PhyStartSending(Ptr<const Packet> packet, uint32_t node);
+
+    /**
+     * This function resets the simulation and device MAC layer, use before test sub-cases.
+     */
+    void Reset();
+
+    void DoRun() override;
+
+    Ptr<ClassAEndDeviceLorawanMac> m_mac; //!< The end device's MAC layer used in tests.
+    Ptr<Packet> m_packet;                 //!< Target packet for tracing
+
+    int m_macSentNewPacketCalls = 0;    //!< Counter for MacSentNewPacket calls
+    int m_macRequiredTransmissions = 0; //!< Counter for MacRequiredTransmissions calls
+    int m_phyStartSendingCalls = 0;     //!< Counter for PhyStartSending calls
+
+    uint8_t m_numTransmissions = 0;   //<! Number of confirmed packet transmissions
+    bool m_successfullyAcked = false; //<! Acknowledgement of confirmed packet
+};
+
+RetransmissionTest::RetransmissionTest()
+    : TestCase("Test the retransmission procedure of the LoRaWAN MAC protocol")
+{
+}
+
+RetransmissionTest::~RetransmissionTest()
+{
+    m_mac = nullptr;
+}
+
+void
+RetransmissionTest::SendUplink(LoraFrameHeader& fhdr)
+{
+    Ptr<Packet> pkt;
+    LorawanMacHeader mhdr;
+    // Send packet through the MAC layer
+    pkt = Create<Packet>(0);
+    m_packet = pkt;
+    Simulator::ScheduleNow(&ClassAEndDeviceLorawanMac::Send, m_mac, pkt);
+    Simulator::Run();
+    pkt->RemoveAtEnd(4); // MIC
+    // Retrieve uplink FHDR
+    pkt->RemoveHeader(mhdr);
+    fhdr.SetAsUplink();
+    pkt->RemoveHeader(fhdr);
+    NS_LOG_LOGIC("Frame Header: " << fhdr);
+}
+
+void
+RetransmissionTest::ScheduleDownlink(Time after, bool ack)
+{
+    Ptr<Packet> pkt;
+    LoraFrameHeader fhdr;
+    LorawanMacHeader mhdr;
+    // Prepare DL packet
+    pkt = Create<Packet>(0);
+    fhdr.SetAsDownlink();
+    fhdr.SetAck(ack);
+    pkt->AddHeader(fhdr);
+    mhdr.SetFType(LorawanMacHeader::UNCONFIRMED_DATA_DOWN);
+    pkt->AddHeader(mhdr);
+    pkt->AddPaddingAtEnd(4); // MIC
+    // Schedule MAC layer reception
+    Simulator::Schedule(after, &ClassAEndDeviceLorawanMac::Receive, m_mac, pkt);
+}
+
+void
+RetransmissionTest::MacSentNewPacket(Ptr<const Packet> packet)
+{
+    m_macSentNewPacketCalls++;
+}
+
+void
+RetransmissionTest::MacRequiredTransmissions(uint8_t transmissions,
+                                             bool successful,
+                                             Time firstAttempt,
+                                             Ptr<Packet> packet)
+{
+    m_macRequiredTransmissions++;
+    if (m_packet == packet)
+    {
+        m_numTransmissions = transmissions;
+        m_successfullyAcked = successful;
+    }
+}
+
+void
+RetransmissionTest::PhyStartSending(Ptr<const Packet> packet, uint32_t node)
+{
+    m_phyStartSendingCalls++;
+}
+
+void
+RetransmissionTest::Reset()
+{
+    m_macSentNewPacketCalls = 0;
+    m_macRequiredTransmissions = 0;
+    m_phyStartSendingCalls = 0;
+    m_numTransmissions = 0;
+    m_successfullyAcked = false;
+    Simulator::Destroy();
+    // Reset MAC state
+    LorawanMacHelper macHelper;
+    macHelper.SetRegion(LorawanMacHelper::EU);
+    macHelper.SetType("ns3::ClassAEndDeviceLorawanMac");
+    m_mac = DynamicCast<ClassAEndDeviceLorawanMac>(macHelper.Install(nullptr));
+    m_mac->SetDataRate(5);
+    m_mac->TraceConnectWithoutContext("SentNewPacket",
+                                      MakeCallback(&RetransmissionTest::MacSentNewPacket, this));
+    m_mac->TraceConnectWithoutContext(
+        "RequiredTransmissions",
+        MakeCallback(&RetransmissionTest::MacRequiredTransmissions, this));
+    NS_TEST_EXPECT_MSG_NE(m_mac, nullptr, "Failed to initialize MAC layer object.");
+    auto phy = CreateObject<EndDeviceLoraPhy>();
+    phy->SetChannel(CreateObject<LoraChannel>());
+    phy->SetMobility(CreateObject<ConstantPositionMobilityModel>());
+    phy->TraceConnectWithoutContext("StartSending",
+                                    MakeCallback(&RetransmissionTest::PhyStartSending, this));
+    m_mac->SetPhy(phy);
+    m_mac->Initialize();
+}
+
+void
+RetransmissionTest::DoRun()
+{
+    NS_LOG_DEBUG("RetransmissionTest");
+
+    Reset();
+    // Unconfirmed send yields the correct number of retransmissions (base case)
+    { // WARNING: default values are manually set here
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected MAC frame counter value");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              1,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Unconfirmed send yields the correct number of retransmissions
+    {
+        uint8_t nbTrans = 4;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Unconfirmed send yields the correct number of retransmissions (limit case)
+    {
+        uint8_t nbTrans = 15;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected MAC frame counter value");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              nbTrans,
+                              "Unexpected number of physical layer transmissions");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Unconfirmed send interrupted in-between retransmissions
+    {
+        uint8_t nbTrans = 9;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        Simulator::Schedule(Seconds(2.5),
+                            &ClassAEndDeviceLorawanMac::Send,
+                            m_mac,
+                            Create<Packet>(0));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 2, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              1 + nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              2,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Unconfirmed send retransmissions interrupted while MAC layer busy
+    {
+        uint8_t nbTrans = 8;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        Simulator::Schedule(Seconds(8), &ClassAEndDeviceLorawanMac::Send, m_mac, Create<Packet>(0));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 2, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              2 + nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              2,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Unconfirmed send retransmissions interrupted after downlink
+    {
+        uint8_t nbTrans = 3;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        ScheduleDownlink(Seconds(1.2));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              1,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Unconfirmed send retransmissions interrupted after downlink (different params)
+    {
+        uint8_t nbTrans = 13;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        ScheduleDownlink(Seconds(30.3));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              5,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              0,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+    }
+
+    Reset();
+    // Confirmed yields the correct number of unacknowledged retransmissions
+    {
+        uint8_t nbTrans = 7;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              1,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+        NS_TEST_ASSERT_MSG_EQ(m_numTransmissions,
+                              nbTrans,
+                              "Unexpected number of transmissions for confirmed packet");
+        NS_TEST_ASSERT_MSG_EQ(m_successfullyAcked,
+                              false,
+                              "Unexpected acknowledgment state for confirmed packet");
+    }
+
+    Reset();
+    // Confirmed send retransmissions interrupted in-between retransmissions
+    {
+        uint8_t nbTrans = 6;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
+        Simulator::Schedule(Seconds(8.5),
+                            &ClassAEndDeviceLorawanMac::Send,
+                            m_mac,
+                            Create<Packet>(0));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 2, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              2 + nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              2,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              2,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+        NS_TEST_ASSERT_MSG_EQ(m_numTransmissions,
+                              2,
+                              "Unexpected number of transmissions for confirmed packet");
+        NS_TEST_ASSERT_MSG_EQ(m_successfullyAcked,
+                              false,
+                              "Unexpected acknowledgment state for confirmed packet");
+    }
+
+    Reset();
+    // Confirmed send retransmissions interrupted interrupted while MAC layer busy
+    {
+        uint8_t nbTrans = 9;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
+        Simulator::Schedule(Seconds(21),
+                            &ClassAEndDeviceLorawanMac::Send,
+                            m_mac,
+                            Create<Packet>(0));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 2, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              3 + nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              2,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              2,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+        NS_TEST_ASSERT_MSG_EQ(m_numTransmissions,
+                              3,
+                              "Unexpected number of transmissions for confirmed packet");
+        NS_TEST_ASSERT_MSG_EQ(m_successfullyAcked,
+                              false,
+                              "Unexpected acknowledgment state for confirmed packet");
+    }
+
+    Reset();
+    // Confirmed send retransmissions not interrupted after downlink without ACK
+    {
+        uint8_t nbTrans = 10;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
+        ScheduleDownlink(Seconds(45));
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              nbTrans,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              1,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+        NS_TEST_ASSERT_MSG_EQ(m_numTransmissions,
+                              nbTrans,
+                              "Unexpected number of transmissions for confirmed packet");
+        NS_TEST_ASSERT_MSG_EQ(m_successfullyAcked,
+                              false,
+                              "Unexpected acknowledgment state for confirmed packet");
+    }
+
+    Reset();
+    // Confirmed send retransmissions interrupted after downlink with ACK
+    {
+        uint8_t nbTrans = 14;
+        m_mac->SetNumberOfTransmissions(nbTrans);
+        m_mac->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
+        ScheduleDownlink(Seconds(67), true);
+        LoraFrameHeader fhdr;
+        SendUplink(fhdr);
+        NS_TEST_EXPECT_MSG_EQ(fhdr.GetFCnt(), 0, "Unexpected FCnt value in uplink FHDR");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFCnt(), 1, "Unexpected FCnt value in MAC layer");
+        NS_TEST_ASSERT_MSG_EQ(m_phyStartSendingCalls,
+                              10,
+                              "Unexpected number of PHY layer StartSending calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macSentNewPacketCalls,
+                              1,
+                              "Unexpected number of MAC layer SendNewPacket calls");
+        NS_TEST_ASSERT_MSG_EQ(m_macRequiredTransmissions,
+                              1,
+                              "Unexpected number of MAC layer RequiredTransmissions calls");
+        NS_TEST_ASSERT_MSG_EQ(m_numTransmissions,
+                              10,
+                              "Unexpected number of transmissions for confirmed packet");
+        NS_TEST_ASSERT_MSG_EQ(m_successfullyAcked,
+                              true,
+                              "Unexpected acknowledgment state for confirmed packet");
+    }
+}
+
+/**
+ * @ingroup lorawan
+ *
  * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
  * TestCases to be run. Typically, only the constructor for this class must be defined
  */
@@ -2613,6 +3100,7 @@ LorawanTestSuite::LorawanTestSuite()
     AddTestCase(new PhyConnectivityTest, Duration::QUICK);
     AddTestCase(new MacCommandTest, Duration::QUICK);
     AddTestCase(new AdrBackoffTest, Duration::QUICK);
+    AddTestCase(new RetransmissionTest, Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2303,6 +2303,33 @@ MacCommandTest::DoRun()
         NS_TEST_EXPECT_MSG_EQ(nca->GetDataRateRangeOk(), false, "DataRateRangeOk != false");
         NS_TEST_EXPECT_MSG_EQ(nca->GetChannelFrequencyOk(), false, "ChannelFrequencyOk != false");
     }
+
+    Reset();
+    // RxTimingSetupReq: change first Rx window delay
+    {
+        uint8_t del = 11;
+        auto answers = RunMacCommand<RxTimingSetupReq>(del);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        NS_TEST_ASSERT_MSG_EQ(
+            m_mac->GetFirstReceiveWindowDelay(),
+            Seconds(del),
+            "First Rx window delay expected to be equal to RxTimingSetupReq delay");
+        auto rtsa = DynamicCast<RxTimingSetupAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(rtsa, nullptr, "NewChannelAns was expected, cmd type cast failed");
+    }
+
+    Reset();
+    // RxTimingSetupReq: 0 delay is set to 1
+    {
+        uint8_t del = 0;
+        auto answers = RunMacCommand<RxTimingSetupReq>(del);
+        NS_TEST_ASSERT_MSG_EQ(answers.size(), 1, "1 answer cmd was expected, found 0 or >1");
+        NS_TEST_ASSERT_MSG_EQ(m_mac->GetFirstReceiveWindowDelay(),
+                              Seconds(1),
+                              "First Rx window delay expected to be equal to 1s");
+        auto rtsa = DynamicCast<RxTimingSetupAns>(*(answers.begin()));
+        NS_TEST_ASSERT_MSG_NE(rtsa, nullptr, "NewChannelAns was expected, cmd type cast failed");
+    }
 }
 
 /**

--- a/test/network-scheduler-test-suite.cc
+++ b/test/network-scheduler-test-suite.cc
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2018 University of Padova
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
  * Author: Davide Magrin <magrinda@dei.unipd.it>
  *
  * 17/01/2023
@@ -6,27 +10,27 @@
  *                              <alessandro.aimi@cnam.fr>
  */
 
-// Include headers of classes to test
-#include "ns3/log.h"
-#include "ns3/network-scheduler.h"
-
 // An essential include is test.h
 #include "ns3/test.h"
+
+// Include headers of classes to test
+#include "ns3/network-scheduler.h"
 
 using namespace ns3;
 using namespace lorawan;
 
 NS_LOG_COMPONENT_DEFINE("NetworkSchedulerTestSuite");
 
-/////////////////////////////
-// NetworkStatus testing //
-/////////////////////////////
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests the correct functionality of the NetworkScheduler component class of the network server
+ */
 class NetworkSchedulerTest : public TestCase
 {
   public:
-    NetworkSchedulerTest();
-    ~NetworkSchedulerTest() override;
+    NetworkSchedulerTest();           //!< Default constructor
+    ~NetworkSchedulerTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -54,25 +58,23 @@ NetworkSchedulerTest::DoRun()
     // scheduled to happen 1 second after the reception.
 }
 
-/**************
- * Test Suite *
- **************/
-
-// The TestSuite class names the TestSuite, identifies what type of TestSuite,
-// and enables the TestCases to be run. Typically, only the constructor for
-// this class must be defined
-
+/**
+ * @ingroup lorawan
+ *
+ * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
+ * TestCases to be run. Typically, only the constructor for this class must be defined
+ */
 class NetworkSchedulerTestSuite : public TestSuite
 {
   public:
-    NetworkSchedulerTestSuite();
+    NetworkSchedulerTestSuite(); //!< Default constructor
 };
 
 NetworkSchedulerTestSuite::NetworkSchedulerTestSuite()
     : TestSuite("network-scheduler", Type::UNIT)
 {
-    LogComponentEnable("NetworkSchedulerTestSuite", LOG_LEVEL_DEBUG);
-    // TestDuration for TestCase can be QUICK, EXTENSIVE or TAKES_FOREVER
+    // LogComponentEnable("NetworkSchedulerTestSuite", LOG_LEVEL_DEBUG);
+
     AddTestCase(new NetworkSchedulerTest, Duration::QUICK);
 }
 

--- a/test/network-server-test-suite.cc
+++ b/test/network-server-test-suite.cc
@@ -1,8 +1,7 @@
 /*
- * This file includes testing for the following components:
- * - EndDeviceServer
- * - GatewayServer
- * - NetworkServer
+ * Copyright (c) 2018 University of Padova
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
  *
  * Author: Davide Magrin <magrinda@dei.unipd.it>
  *
@@ -11,44 +10,60 @@
  *                              <alessandro.aimi@cnam.fr>
  */
 
-// Include headers of classes to test
+/*
+ * This file includes testing for the following components:
+ * - NetworkServer
+ */
+
 #include "utilities.h"
 
-#include "ns3/callback.h"
-#include "ns3/core-module.h"
-#include "ns3/log.h"
-#include "ns3/network-server-helper.h"
-#include "ns3/network-server.h"
-
 // An essential include is test.h
+#include "ns3/application.h"
+#include "ns3/simulator.h"
 #include "ns3/test.h"
+
+// Include headers of classes to test
+#include "ns3/class-a-end-device-lorawan-mac.h"
 
 using namespace ns3;
 using namespace lorawan;
 
 NS_LOG_COMPONENT_DEFINE("NetworkServerTestSuite");
 
-///////////////////////////
-// NetworkServer testing //
-///////////////////////////
-
+/**
+ * @ingroup lorawan
+ *
+ * It verifies that the NetworkServer application can receive packets sent in uplink by devices
+ */
 class UplinkPacketTest : public TestCase
 {
   public:
-    UplinkPacketTest();
-    ~UplinkPacketTest() override;
+    UplinkPacketTest();           //!< Default constructor
+    ~UplinkPacketTest() override; //!< Destructor
 
+    /**
+     * Callback for tracing ReceivedPacket.
+     *
+     * @param packet The packet received.
+     */
     void ReceivedPacket(Ptr<const Packet> packet);
+
+    /**
+     * Send a packet from the input end device.
+     *
+     * @param endDevice A pointer to the end device Node.
+     */
     void SendPacket(Ptr<Node> endDevice);
 
   private:
     void DoRun() override;
-    bool m_receivedPacket = false;
+
+    bool m_receivedPacket = false; //!< Set to true if a packet is received by the server
 };
 
 // Add some help text to this case to describe what it is intended to test
 UplinkPacketTest::UplinkPacketTest()
-    : TestCase("Verify that the NetworkServer can receive"
+    : TestCase("Verify that the NetworkServer application can receive"
                " packets sent in the uplink by devices")
 {
 }
@@ -61,7 +76,7 @@ UplinkPacketTest::~UplinkPacketTest()
 void
 UplinkPacketTest::ReceivedPacket(Ptr<const Packet> packet)
 {
-    NS_LOG_DEBUG("Received a packet at the NS");
+    NS_LOG_DEBUG("Received a packet at the network server");
     m_receivedPacket = true;
 }
 
@@ -103,31 +118,51 @@ UplinkPacketTest::DoRun()
     NS_ASSERT(m_receivedPacket == true);
 }
 
-////////////////////////
-// DownlinkPacketTest //
-////////////////////////
-
+/**
+ * @ingroup lorawan
+ *
+ * It verifies that devices requesting an acknowledgment receive a reply from the network server
+ */
 class DownlinkPacketTest : public TestCase
 {
   public:
-    DownlinkPacketTest();
-    ~DownlinkPacketTest() override;
+    DownlinkPacketTest();           //!< Default constructor
+    ~DownlinkPacketTest() override; //!< Destructor
 
+    /**
+     * Record the exit status of a MAC layer packet retransmission process of an end device.
+     *
+     * This trace sink is only used here to determine whether an ack was received by the end device
+     * after sending a package requiring an acknowledgement.
+     *
+     * @param requiredTransmissions Number of transmissions attempted during the process.
+     * @param success Whether the retransmission procedure was successful.
+     * @param time Timestamp of the initial transmission attempt.
+     * @param packet The packet being retransmitted.
+     */
     void ReceivedPacketAtEndDevice(uint8_t requiredTransmissions,
                                    bool success,
                                    Time time,
                                    Ptr<Packet> packet);
+
+    /**
+     * Send a packet from the input end device.
+     *
+     * @param endDevice A pointer to the end device Node.
+     * @param requestAck Whether to require an acknowledgement from the server.
+     */
     void SendPacket(Ptr<Node> endDevice, bool requestAck);
 
   private:
     void DoRun() override;
-    bool m_receivedPacketAtEd = false;
+
+    bool m_receivedPacketAtEd = false; //!< Set to true if a packet is received by the end device
 };
 
 // Add some help text to this case to describe what it is intended to test
 DownlinkPacketTest::DownlinkPacketTest()
     : TestCase("Verify that devices requesting an acknowledgment receive"
-               " a reply from the Network Server.")
+               " a reply from the network server.")
 {
 }
 
@@ -142,7 +177,7 @@ DownlinkPacketTest::ReceivedPacketAtEndDevice(uint8_t requiredTransmissions,
                                               Time time,
                                               Ptr<Packet> packet)
 {
-    NS_LOG_DEBUG("Received a packet at the ED");
+    NS_LOG_DEBUG("Received a packet at the end device");
     m_receivedPacketAtEd = success;
 }
 
@@ -172,7 +207,7 @@ DownlinkPacketTest::DoRun()
     NodeContainer gateways = components.gateways;
     Ptr<Node> nsNode = components.nsNode;
 
-    // Connect the ED's trace source for received packets
+    // Connect the end device's trace source for received packets
     DynamicCast<BaseEndDeviceLorawanMac>(
         DynamicCast<LoraNetDevice>(endDevices.Get(0)->GetDevice(0))->GetMac())
         ->TraceConnectWithoutContext(
@@ -189,29 +224,46 @@ DownlinkPacketTest::DoRun()
     NS_ASSERT(m_receivedPacketAtEd);
 }
 
-//////////////////////////
-// LinkCheckSupportTest //
-//////////////////////////
-
+/**
+ * @ingroup lorawan
+ *
+ * It verifies that the NetworkServer application correctly responds to LinkCheck requests
+ */
 class LinkCheckTest : public TestCase
 {
   public:
-    LinkCheckTest();
-    ~LinkCheckTest() override;
+    LinkCheckTest();           //!< Default constructor
+    ~LinkCheckTest() override; //!< Destructor
 
-    void LastKnownGatewayCount(int newValue, int oldValue);
+    /**
+     * Trace changes in the last known gateway count variable (updated on reception of
+     * LinkCheckAns MAC commands) of an end device.
+     *
+     * @param newValue The updated value.
+     * @param oldValue The previous value.
+     */
+    void LastKnownGatewayCount(uint8_t newValue, uint8_t oldValue);
 
+    /**
+     * Send a packet containing a LinkCheckReq MAC command from the input end device.
+     *
+     * @param endDevice A pointer to the end device Node.
+     * @param requestAck Whether to require an acknowledgement from the server.
+     */
     void SendPacket(Ptr<Node> endDevice, bool requestAck);
 
   private:
     void DoRun() override;
-    bool m_receivedPacketAtEd = false;
-    int m_numberOfGatewaysThatReceivedPacket = 0;
+    bool m_receivedPacketAtEd = false; //!< Set to true if a packet containing a LinkCheckAns MAC
+                                       //!< command is received by the end device
+    uint8_t m_numberOfGatewaysThatReceivedPacket =
+        0; //!< Stores the number of gateways that received the last packet carrying a
+           //!< LinkCheckReq MAC command
 };
 
 // Add some help text to this case to describe what it is intended to test
 LinkCheckTest::LinkCheckTest()
-    : TestCase("Verify that the NetworkServer correctly responds to "
+    : TestCase("Verify that the NetworkServer application correctly responds to "
                "LinkCheck requests")
 {
 }
@@ -222,9 +274,9 @@ LinkCheckTest::~LinkCheckTest()
 }
 
 void
-LinkCheckTest::LastKnownGatewayCount(int newValue, int oldValue)
+LinkCheckTest::LastKnownGatewayCount(uint8_t newValue, uint8_t oldValue)
 {
-    NS_LOG_DEBUG("Updated Gateway Count");
+    NS_LOG_DEBUG("Updated gateway count");
     m_receivedPacketAtEd = true;
 
     m_numberOfGatewaysThatReceivedPacket = newValue;
@@ -235,10 +287,12 @@ LinkCheckTest::SendPacket(Ptr<Node> endDevice, bool requestAck)
 {
     auto macLayer = DynamicCast<BaseEndDeviceLorawanMac>(
         DynamicCast<LoraNetDevice>(endDevice->GetDevice(0))->GetMac());
+
     if (requestAck)
     {
         macLayer->SetFType(LorawanMacHeader::CONFIRMED_DATA_UP);
     }
+
     macLayer->AddMacCommand(Create<LinkCheckReq>());
     macLayer->Send(Create<Packet>(20));
 }
@@ -258,7 +312,7 @@ LinkCheckTest::DoRun()
     NodeContainer gateways = components.gateways;
     Ptr<Node> nsNode = components.nsNode;
 
-    // Connect the ED's trace source for Last known Gateway Count
+    // Connect the end device's trace source for last known gateway count
     DynamicCast<BaseEndDeviceLorawanMac>(
         DynamicCast<LoraNetDevice>(endDevices.Get(0)->GetDevice(0))->GetMac())
         ->TraceConnectWithoutContext("LastKnownGatewayCount",
@@ -274,44 +328,102 @@ LinkCheckTest::DoRun()
     NS_ASSERT(m_receivedPacketAtEd);
 }
 
-/**************
- * Test Suite *
- **************/
+/**
+ * @ingroup lorawan
+ *
+ * It verifies that the NetworkServer application responds to uplinks with the ADRACKReq bit set
+ */
+class AdrAckReqTest : public TestCase
+{
+  public:
+    AdrAckReqTest();           //!< Default constructor
+    ~AdrAckReqTest() override; //!< Destructor
 
-// The TestSuite class names the TestSuite, identifies what type of TestSuite,
-// and enables the TestCases to be run. Typically, only the constructor for
-// this class must be defined
+  private:
+    void DoRun() override;
 
+    /**
+     * Callback for packet reception by the end device MAC layer
+     *
+     * @param packet The received packet
+     */
+    void OnReception(Ptr<const Packet> packet);
+
+    bool m_adrAckReceived = false; //!< Set to true if a downlink packet is received by the end
+                                   //!< device after setting the uplink ADRACKReq bit
+};
+
+AdrAckReqTest::AdrAckReqTest()
+    : TestCase("Verify that the NetworkServer responds to uplinks with the ADRACKReq bit set")
+{
+}
+
+AdrAckReqTest::~AdrAckReqTest()
+{
+}
+
+void
+AdrAckReqTest::OnReception(Ptr<const Packet> packet)
+{
+    m_adrAckReceived = true;
+}
+
+void
+AdrAckReqTest::DoRun()
+{
+    NS_LOG_DEBUG("AdrAckReqTest");
+    auto components = InitializeNetwork(1, 1);
+    auto ed = components.endDevices.Get(0);
+    auto netdev = DynamicCast<LoraNetDevice>(ed->GetDevice(0));
+    auto mac = DynamicCast<ClassAEndDeviceLorawanMac>(netdev->GetMac());
+    // Turn-off ADR downlinks from the server, ADRACKReq mechanism still works
+    mac->SetAttribute("ADR", BooleanValue(false));
+    auto cb = MakeCallback(&AdrAckReqTest::OnReception, this);
+    mac->TraceConnectWithoutContext("ReceivedPacket", cb);
+    // Trigger ADRACKReq bit set
+    for (uint16_t fCnt = 0; fCnt <= ADR_ACK_LIMIT; ++fCnt)
+    {
+        Simulator::Schedule(Minutes(20), &ClassAEndDeviceLorawanMac::Send, mac, Create<Packet>(20));
+        Simulator::Run();
+    }
+    NS_TEST_EXPECT_MSG_EQ(m_adrAckReceived, true, "No downlink received by the end device");
+}
+
+/**
+ * @ingroup lorawan
+ *
+ * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
+ * TestCases to be run. Typically, only the constructor for this class must be defined
+ */
 class NetworkServerTestSuite : public TestSuite
 {
   public:
-    NetworkServerTestSuite();
+    NetworkServerTestSuite(); //!< Default constructor
 };
 
 NetworkServerTestSuite::NetworkServerTestSuite()
     : TestSuite("network-server", Type::UNIT)
 {
-    LogComponentEnable("NetworkServerTestSuite", LOG_LEVEL_DEBUG);
+    // Activate only at need, as these can create problems among test suites when running ./test.py
+    // LogComponentEnable("NetworkServerTestSuite", LOG_LEVEL_DEBUG);
+    // LogComponentEnable("NetworkServer", LOG_LEVEL_ALL);
+    // LogComponentEnable("NetworkStatus", LOG_LEVEL_ALL);
+    // LogComponentEnable("NetworkScheduler", LOG_LEVEL_ALL);
+    // LogComponentEnable("NetworkController", LOG_LEVEL_ALL);
+    // LogComponentEnable("NetworkControllerComponent", LOG_LEVEL_ALL);
+    // LogComponentEnable("LoraNetDevice", LOG_LEVEL_ALL);
+    // LogComponentEnable("GatewayLorawanMac", LOG_LEVEL_ALL);
+    // LogComponentEnable("BaseEndDeviceLorawanMac", LOG_LEVEL_ALL);
+    // LogComponentEnable("EndDeviceLoraPhy", LOG_LEVEL_ALL);
+    // LogComponentEnable("EndDeviceStatus", LOG_LEVEL_ALL);
+    // LogComponentEnableAll(LOG_PREFIX_FUNC);
+    // LogComponentEnableAll(LOG_PREFIX_NODE);
+    // LogComponentEnableAll(LOG_PREFIX_TIME);
 
-    LogComponentEnable("NetworkServer", LOG_LEVEL_ALL);
-    LogComponentEnable("NetworkStatus", LOG_LEVEL_ALL);
-    LogComponentEnable("NetworkScheduler", LOG_LEVEL_ALL);
-    LogComponentEnable("NetworkController", LOG_LEVEL_ALL);
-    LogComponentEnable("NetworkControllerComponent", LOG_LEVEL_ALL);
-    LogComponentEnable("LoraNetDevice", LOG_LEVEL_ALL);
-    LogComponentEnable("GatewayLorawanMac", LOG_LEVEL_ALL);
-    LogComponentEnable("BaseEndDeviceLorawanMac", LOG_LEVEL_ALL);
-    LogComponentEnable("EndDeviceLoraPhy", LOG_LEVEL_ALL);
-    LogComponentEnable("EndDeviceStatus", LOG_LEVEL_ALL);
-
-    LogComponentEnableAll(LOG_PREFIX_FUNC);
-    LogComponentEnableAll(LOG_PREFIX_NODE);
-    LogComponentEnableAll(LOG_PREFIX_TIME);
-
-    // TestDuration for TestCase can be QUICK, EXTENSIVE or TAKES_FOREVER
     AddTestCase(new UplinkPacketTest, Duration::QUICK);
     AddTestCase(new DownlinkPacketTest, Duration::QUICK);
     AddTestCase(new LinkCheckTest, Duration::QUICK);
+    AddTestCase(new AdrAckReqTest, Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite

--- a/test/network-status-test-suite.cc
+++ b/test/network-status-test-suite.cc
@@ -1,8 +1,7 @@
 /*
- * This file includes testing for the following components:
- * - EndDeviceStatus
- * - GatewayStatus
- * - NetworkStatus
+ * Copyright (c) 2018 University of Padova
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
  *
  * Author: Davide Magrin <magrinda@dei.unipd.it>
  *
@@ -11,30 +10,37 @@
  *                              <alessandro.aimi@cnam.fr>
  */
 
-// Include headers of classes to test
-#include "utilities.h"
+/*
+ * This file includes testing for the following components:
+ * - EndDeviceStatus
+ * - GatewayStatus
+ * - NetworkStatus
+ */
 
-#include "ns3/end-device-status.h"
-#include "ns3/log.h"
-#include "ns3/network-status.h"
+#include "utilities.h"
 
 // An essential include is test.h
 #include "ns3/test.h"
+
+// Include headers of classes to test
+#include "ns3/class-a-end-device-lorawan-mac.h"
+#include "ns3/network-status.h"
 
 using namespace ns3;
 using namespace lorawan;
 
 NS_LOG_COMPONENT_DEFINE("NetworkStatusTestSuite");
 
-/////////////////////////////
-// EndDeviceStatus testing //
-/////////////////////////////
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests the constructor of the EndDeviceStatus class
+ */
 class EndDeviceStatusTest : public TestCase
 {
   public:
-    EndDeviceStatusTest();
-    ~EndDeviceStatusTest() override;
+    EndDeviceStatusTest();           //!< Default constructor
+    ~EndDeviceStatusTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -62,15 +68,16 @@ EndDeviceStatusTest::DoRun()
     EndDeviceStatus eds = EndDeviceStatus();
 }
 
-/////////////////////////////
-// NetworkStatus testing //
-/////////////////////////////
-
+/**
+ * @ingroup lorawan
+ *
+ * It tests the function NetworkStatus::AddNode
+ */
 class NetworkStatusTest : public TestCase
 {
   public:
-    NetworkStatusTest();
-    ~NetworkStatusTest() override;
+    NetworkStatusTest();           //!< Default constructor
+    ~NetworkStatusTest() override; //!< Destructor
 
   private:
     void DoRun() override;
@@ -107,25 +114,23 @@ NetworkStatusTest::DoRun()
     ns.AddNode(GetMacLayerFromNode<ClassAEndDeviceLorawanMac>(endDevices.Get(0)));
 }
 
-/**************
- * Test Suite *
- **************/
-
-// The TestSuite class names the TestSuite, identifies what type of TestSuite,
-// and enables the TestCases to be run. Typically, only the constructor for
-// this class must be defined
-
+/**
+ * @ingroup lorawan
+ *
+ * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
+ * TestCases to be run. Typically, only the constructor for this class must be defined
+ */
 class NetworkStatusTestSuite : public TestSuite
 {
   public:
-    NetworkStatusTestSuite();
+    NetworkStatusTestSuite(); //!< Default constructor
 };
 
 NetworkStatusTestSuite::NetworkStatusTestSuite()
     : TestSuite("network-status", Type::UNIT)
 {
-    LogComponentEnable("NetworkStatusTestSuite", LOG_LEVEL_DEBUG);
-    // TestDuration for TestCase can be QUICK, EXTENSIVE or TAKES_FOREVER
+    // LogComponentEnable("NetworkStatusTestSuite", LOG_LEVEL_DEBUG);
+
     AddTestCase(new EndDeviceStatusTest, Duration::QUICK);
     AddTestCase(new NetworkStatusTest, Duration::QUICK);
 }

--- a/test/utilities.cc
+++ b/test/utilities.cc
@@ -1,4 +1,19 @@
+/*
+ * Copyright (c) 2018 University of Padova
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Authors: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
 #include "utilities.h"
+
+#include "ns3/forwarder-helper.h"
+#include "ns3/lorawan-helper.h"
+#include "ns3/mobility-model.h"
+#include "ns3/network-server-helper.h"
+#include "ns3/point-to-point-helper.h"
+#include "ns3/string.h"
 
 namespace ns3
 {
@@ -76,7 +91,7 @@ CreateGateways(int nGateways, MobilityHelper mobility, Ptr<LoraChannel> channel)
 Ptr<Node>
 CreateNetworkServer(NodeContainer endDevices, NodeContainer gateways)
 {
-    // Create the NetworkServer node
+    // Create the network server node
     Ptr<Node> nsNode = CreateObject<Node>();
 
     // PointToPoint links between gateways and server

--- a/test/utilities.h
+++ b/test/utilities.h
@@ -5,26 +5,31 @@
  *
  * Authors: Davide Magrin <magrinda@dei.unipd.it>
  */
+
 #ifndef TEST_UTILITIES_H
 #define TEST_UTILITIES_H
 
-#include "ns3/forwarder-helper.h"
-#include "ns3/lorawan-helper.h"
+#include "ns3/lora-channel.h"
+#include "ns3/lora-net-device.h"
 #include "ns3/mobility-helper.h"
-#include "ns3/network-server-helper.h"
-#include "ns3/position-allocator.h"
+#include "ns3/node-container.h"
 
 namespace ns3
 {
 namespace lorawan
 {
 
+/**
+ * @ingroup lorawan
+ *
+ * Stores the main elements of a simulated LoRaWAN network
+ */
 struct NetworkComponents
 {
-    Ptr<LoraChannel> channel;
-    NodeContainer endDevices;
-    NodeContainer gateways;
-    Ptr<Node> nsNode;
+    Ptr<LoraChannel> channel; //!< A pointer to the LoraChannel object.
+    NodeContainer endDevices; //!< Container of the end device nodes.
+    NodeContainer gateways;   //!< Container of the gateway nodes.
+    Ptr<Node> nsNode;         //!< A pointer to the network server Node.
 };
 
 Ptr<LoraChannel> CreateChannel();
@@ -43,7 +48,8 @@ GetMacLayerFromNode(Ptr<Node> n)
 }
 
 NetworkComponents InitializeNetwork(int nDevices, int nGateways);
-} // namespace lorawan
 
+} // namespace lorawan
 } // namespace ns3
-#endif
+
+#endif /* TEST_UTILITIES_H */


### PR DESCRIPTION
## Description

This PR fixes `BaseEndDeviceLorawanMac::OnLinkAdrReq()` handling for the
special `LinkADRReq` values:
- `DataRate = 0xF`
- `TXPower = 0xF`

In LoRaWAN ADR processing, these values mean "keep current value" and should
not be interpreted as new DR / TX power settings to validate and apply.[1]

## Problem

During interoperability testing with The Things Stack / TTN, the end device
received `LinkADRReq` with `DataRate = 15 (0xF)` and `TXPower = 15 (0xF)`.

According to LoRaWAN ADR handling, `DataRate = 0xF` means the device should
continue using its current data rate, and the request should be processed using
that effective value instead of treating `15` as a normal DR setting.[1]
Likewise, `TXPower = 0xF` means the current TX power should be kept.[1]

In the previous implementation, these special values were passed through the
regular validation path. As a result, `DataRate = 15` was converted to
`SF: 0, BW: 0`, which caused `DataRateOk = false`, and `TXPower = 15` also
caused `txPowerOk = false`.

### Before fix

```text
2026-04-18T14:26:57.356196138Z +4960.987387744s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(0x7ffd4fab2e40, 15, 15, 2)
2026-04-18T14:26:57.356206517Z +4960.987387744s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): SF: 0, BW: 0
2026-04-18T14:26:57.356242305Z +4960.987387744s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Data rate non valid
2026-04-18T14:26:57.356303943Z +4960.987387744s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Finished checking. ChannelMaskOk: true, DataRateOk: false, txPowerOk: false | Dev Addr.: 1100100|0000000000000000000000000
```

This caused the device to reject a request that should instead preserve the
current DR/TX power while still processing the applicable channel-mask update
and generating a correct `LinkADRAns` response.[1][2]

## Changes

- Skip DR validation when `dataRate == 0xF`
- Skip TX power validation when `txPower == 0xF`
- Update `m_dataRate` only when `dataRate != 0xF`
- Update `m_txPower` only when `txPower != 0xF`
- Keep channel mask processing unchanged
- Add code comments documenting the `0xF` special-case behavior

## Validation

I reproduced the issue while testing eLoRa with The Things Stack / TTN and
verified that after this change the request is accepted and the current DR /
TX power are preserved.

### After fix

```text
2026-04-21T13:52:29.938560388Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(0x7ffc7b0d80d8, 15, 15, 1)
2026-04-21T13:52:29.938678943Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Finished checking. ChannelMaskOk: true, DataRateOk: true, txPowerOk: true | Dev Addr.: 1100101|0000000000000000000000001
2026-04-21T13:52:29.938721705Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 0 enabled
2026-04-21T13:52:29.938734884Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 1 enabled
2026-04-21T13:52:29.938762162Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 2 enabled
2026-04-21T13:52:29.938812216Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 3 enabled
2026-04-21T13:52:29.938848437Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 4 enabled
2026-04-21T13:52:29.938897128Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 5 enabled
2026-04-21T13:52:29.938932454Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 6 enabled
2026-04-21T13:52:29.938981831Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): Channel 7 enabled
2026-04-21T13:52:29.939028401Z +2717.202885392s 1 BaseEndDeviceLorawanMac:OnLinkAdrReq(): DR: 5 | TX Power: 8 | m_nbTrans: 1 | Dev Addr.: 1100101|0000000000000000000000001
```

After the fix, the command is accepted with:
- `ChannelMaskOk = true`
- `DataRateOk = true`
- `txPowerOk = true`

and the device keeps its previous DR and TX power (`DR: 5`, `TX Power: 8`)
while applying the requested channel configuration, which matches the expected
handling for `0xF` special values.[1][2]

## References

1. Semtech Learn, “Interpret LinkADRReq commands”  
   https://learn.semtech.com/mod/book/view.php?id=174&chapterid=159

2. Semtech Learn, “Respond with LinkADRAns”  
   https://learn.semtech.com/mod/book/view.php?id=174&chapterid=161

3. Related implementation reference:  
   https://github.com/signetlabdei/lorawan/blob/develop/model/end-device-lorawan-mac.cc

## Notes

This PR fixes the `0xF` special-value handling bug in
`BaseEndDeviceLorawanMac::OnLinkAdrReq()`.

There is still a remaining gap regarding ADR-enabled vs ADR-disabled handling.
The `signetlabdei/lorawan/Model/EndDeviceLorawanMac` implementation distinguishes these cases more
explicitly, while this patch focuses only on correcting `DataRate = 0xF` and
`TXPower = 0xF` behavior.