### PR TITLE
Bug fix: FCnt updated too early

### DIFF
--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -112,13 +112,13 @@ BaseEndDeviceLorawanMac::BaseEndDeviceLorawanMac()
       m_txPower(14),
       m_nbTrans(1),
       // Protected MAC layer context
+      m_fCnt(0),
       m_ADRACKCnt(0),
       m_ADRACKReq(false),
       // Private Header fields
       m_fType(LorawanMacHeader::UNCONFIRMED_DATA_UP),
       m_address(LoraDeviceAddress(0)),
       m_ADRBit(false),
-      m_fCnt(0),
       // Private MAC layer settings
       m_enableADRBackoff(false),
       m_enableCrypto(false),
@@ -205,16 +205,22 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
     // If this is the transmission of a new packet, overwrite context
     if (packetIsNew)
     {
-        // Tracing: previous packet was not acknowledged, reTxs procedure interrupted
+        // Previous packet was not acknowledged, reTxs procedure interrupted
         if (m_txContext.nbTxLeft && m_txContext.waitingAck)
         {
-            // Call the callback to notify about the failure
+            // Tracing: call the callback to notify about the failure
             uint8_t txs = m_nbTrans - m_txContext.nbTxLeft;
             m_requiredTxCallback(txs, false, m_txContext.firstAttempt, m_txContext.packet);
             NS_LOG_DEBUG(" Received new packet from the application layer: stopping retransmission "
                          "procedure. Previous packet not acknowledged. Used "
                          << unsigned(txs) << " transmissions out of a maximum of "
                          << unsigned(m_nbTrans) << ".");
+            // Update frame counters (normally updated after exausting all reTxs)
+            m_fCnt++;
+            if (m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
+            {
+                m_ADRACKCnt++;
+            }
         }
         m_txContext = {Simulator::Now(),
                        packet,
@@ -272,15 +278,9 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
     SendToPhy(packet);
     // Decrease transmissions counter
     m_txContext.nbTxLeft--;
+    // Fire trace source
     if (packetIsNew)
     {
-        // Increase frame counter
-        m_fCnt++;
-        if (m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
-        {
-            m_ADRACKCnt++;
-        }
-        // Fire trace source
         m_sentNewPacket(packet);
     }
 }

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -173,7 +173,7 @@ BaseEndDeviceLorawanMac::GetNextTransmissionDelay()
     for (const auto& llc : m_channelManager->GetEnabledChannelList())
     {
         waitingTime = std::min(waitingTime, m_channelManager->GetWaitingTime(llc));
-        NS_LOG_DEBUG("Waiting time before the next transmission in channel with frequecy "
+        NS_LOG_DEBUG("Waiting time before the next transmission in channel with frequency "
                      << llc->GetFrequency() << " is = " << waitingTime.GetSeconds() << ".");
     }
 
@@ -205,23 +205,28 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
     // If this is the transmission of a new packet, overwrite context
     if (packetIsNew)
     {
-        // Previous packet was not acknowledged, reTxs procedure interrupted
-        if (m_txContext.nbTxLeft && m_txContext.waitingAck)
+        // If re-transmissions of last packet were interrupted, update frame counters
+        if (m_txContext.nbTxLeft)
         {
-            // Tracing: call the callback to notify about the failure
-            uint8_t txs = m_nbTrans - m_txContext.nbTxLeft;
-            m_requiredTxCallback(txs, false, m_txContext.firstAttempt, m_txContext.packet);
-            NS_LOG_DEBUG(" Received new packet from the application layer: stopping retransmission "
-                         "procedure. Previous packet not acknowledged. Used "
-                         << unsigned(txs) << " transmissions out of a maximum of "
-                         << unsigned(m_nbTrans) << ".");
-            // Update frame counters (normally updated after exausting all reTxs)
+            // Trace if previous confirmed packet was not acknowledged
+            if (m_txContext.waitingAck)
+            {
+                uint8_t txs = m_nbTrans - m_txContext.nbTxLeft;
+                m_requiredTxCallback(txs, false, m_txContext.firstAttempt, m_txContext.packet);
+                NS_LOG_DEBUG(
+                    " Received new packet from the application layer: stopping retransmission "
+                    "procedure. Previous packet not acknowledged. Used "
+                    << unsigned(txs) << " transmissions out of a maximum of " << unsigned(m_nbTrans)
+                    << ".");
+            }
+            // Update frame counter and ADRACKCnt (normally updated after exhausting all reTxs)
             m_fCnt++;
             if (m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
             {
                 m_ADRACKCnt++;
             }
         }
+        // Reset reTx context
         m_txContext = {Simulator::Now(),
                        packet,
                        m_nbTrans,

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -227,11 +227,11 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
             }
         }
         // Reset reTx context
-        m_txContext = {Simulator::Now(),
-                       packet,
-                       m_nbTrans,
-                       m_fType == LorawanMacHeader::CONFIRMED_DATA_UP,
-                       false};
+        m_txContext = {.firstAttempt = Simulator::Now(),
+                       .packet = packet,
+                       .nbTxLeft = m_nbTrans,
+                       .waitingAck = (m_fType == LorawanMacHeader::CONFIRMED_DATA_UP),
+                       .busy = false};
         NS_LOG_DEBUG("New APP packet: " << packet << ".");
     }
     else // Retransmission

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -260,6 +260,11 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     // Protected MAC Layer context //
     /////////////////////////////////
 
+    /**
+     * Uplink frame counter of the device
+     */
+    uint16_t m_fCnt;
+
     /* Counter for keepalive purposes */
     uint16_t m_ADRACKCnt;
 
@@ -453,11 +458,6 @@ class BaseEndDeviceLorawanMac : public LorawanMac
      * Whether this device's data rate should be controlled by the NS.
      */
     bool m_ADRBit;
-
-    /**
-     * Uplink frame counter of the device
-     */
-    uint16_t m_fCnt;
 
     ////////////////////////////////
     // Private MAC Layer settings //

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -241,9 +241,10 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
         return;
     }
 
-    // Update frame counters
+    // Update uplink frame counter
     m_fCnt++;
-    if (m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
+    // Update ADRACKCnt only if nothing was received
+    if (!recv && m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
     {
         m_ADRACKCnt++;
     }

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -241,6 +241,14 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
         return;
     }
 
+    // Update frame counters
+    m_fCnt++;
+    if (m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
+    {
+        m_ADRACKCnt++;
+    }
+
+    // Tracing
     uint8_t txs = m_nbTrans - m_txContext.nbTxLeft;
     // Acknowledgement success of confirmed txs
     if (recv && needAck && gotAck)
@@ -248,7 +256,6 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
         m_requiredTxCallback(txs, true, m_txContext.firstAttempt, m_txContext.packet);
         NS_LOG_DEBUG("Received ACK packet after "
                      << unsigned(txs) << " transmissions: stopping retransmission procedure. ");
-        return;
     }
     // Acknowledgement failure of confirmed txs
     else if (needAck && !gotAck && !canReTx)
@@ -256,7 +263,6 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
         m_requiredTxCallback(txs, false, m_txContext.firstAttempt, m_txContext.packet);
         NS_LOG_DEBUG("Ack failure: no more retransmissions left. Used " << unsigned(txs)
                                                                         << " transmissions.");
-        return;
     }
 }
 

--- a/model/mac/class-a-end-device-lorawan-mac.cc
+++ b/model/mac/class-a-end-device-lorawan-mac.cc
@@ -194,7 +194,7 @@ ClassAEndDeviceLorawanMac::FailedReception(Ptr<const Packet> packet)
     NS_LOG_FUNCTION(this << packet);
     // Ensure device is sleeping without canceling future reception windows
     m_rwm->ForceSleep();
-    // Check if we have exahusted the reception windows
+    // Check if we have exhausted the reception windows
     if (m_rwm->NoMoreWindows())
     {
         ManageRetransmissions(FAIL);
@@ -241,15 +241,7 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
         return;
     }
 
-    // Update uplink frame counter
-    m_fCnt++;
-    // Update ADRACKCnt only if nothing was received
-    if (!recv && m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
-    {
-        m_ADRACKCnt++;
-    }
-
-    // Tracing
+    // Tracing: end of re-transmission procedure
     uint8_t txs = m_nbTrans - m_txContext.nbTxLeft;
     // Acknowledgement success of confirmed txs
     if (recv && needAck && gotAck)
@@ -259,11 +251,23 @@ ClassAEndDeviceLorawanMac::ManageRetransmissions(RxOutcome outcome)
                      << unsigned(txs) << " transmissions: stopping retransmission procedure. ");
     }
     // Acknowledgement failure of confirmed txs
+    // (either exhausted all reTxs or new pkt scheduled while busy)
     else if (needAck && !gotAck && !canReTx)
     {
         m_requiredTxCallback(txs, false, m_txContext.firstAttempt, m_txContext.packet);
-        NS_LOG_DEBUG("Ack failure: no more retransmissions left. Used " << unsigned(txs)
-                                                                        << " transmissions.");
+        NS_LOG_DEBUG("Ack failure: no more retransmission opportunities. Used "
+                     << unsigned(txs) << " transmissions.");
+    }
+
+    // Exhaust remaining re-transmissions
+    m_txContext.nbTxLeft = 0;
+
+    // Update uplink frame counter
+    m_fCnt++;
+    // Update ADRACKCnt only if nothing was received
+    if (!recv && m_ADRACKCnt < MAX_ADR_ACK_CNT) // overflow prevention
+    {
+        m_ADRACKCnt++;
     }
 }
 


### PR DESCRIPTION
Frame counters were increased just after a packet was sent to the PHY layer. Thus, in case of automatic re-transmissions, re-transmitted packets would have an higher FCnt than the original one. Fixed by moving the frame counters update in two places: (i) inside ClassAEndDeviceLorawanMac::ManageRetransmissions(), called the end of the 2-window reception process, and (ii) at the top of  BaseEndDeviceLorawanMac::DoSend() in case a new application packet overwrites the re-transmission process.