### PR TITLE
Bug fix: FCnt updated too early for retransmissions

### DIFF
--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -225,6 +225,9 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
     }
     else // Retransmission
     {
+        // Getting the last fcnt and adrackcnt from the context
+        m_fCnt = m_txContext.fcnt;
+        m_ADRACKCnt = m_txContext.adrackcnt;
         // Remove MIC and headers
         packet->RemoveAtEnd(4);
         LorawanMacHeader mHdr;
@@ -232,6 +235,11 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
         LoraFrameHeader fHdr;
         fHdr.SetAsUplink();
         packet->RemoveHeader(fHdr);
+
+        if(m_txContext.nbTxLeft == 1){
+            // Set the check true in order to update the fcnt adrackcnt later
+            packetIsNew=true;
+        }
         NS_LOG_DEBUG("Retransmitting an old packet.");
     }
 

--- a/model/mac/base-end-device-lorawan-mac.cc
+++ b/model/mac/base-end-device-lorawan-mac.cc
@@ -218,6 +218,8 @@ BaseEndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
         }
         m_txContext = {Simulator::Now(),
                        packet,
+                       m_fCnt,
+                       m_ADRACKCnt,
                        m_nbTrans,
                        m_fType == LorawanMacHeader::CONFIRMED_DATA_UP,
                        false};

--- a/model/mac/base-end-device-lorawan-mac.h
+++ b/model/mac/base-end-device-lorawan-mac.h
@@ -43,6 +43,8 @@ class BaseEndDeviceLorawanMac : public LorawanMac
     {
         Time firstAttempt;
         Ptr<Packet> packet = nullptr;
+        uint16_t fcnt; // to Track the last fcnt
+        uint16_t adrackcnt;  // to Track the last adrackcnt
         uint8_t nbTxLeft;
         bool waitingAck = false;
         bool busy = false;


### PR DESCRIPTION
Frame counters were previously incremented immediately after a packet was handed to the PHY layer. As a result, automatic retransmissions used a higher FCnt than the original transmission.

This issue was fixed by storing both FCnt and AdrAckCnt in m_txContext. During retransmission, these stored values are reused so that retransmitted packets keep the same counters as the original one. In addition, the packetIsNew flag is now set to true for the final retransmission.
